### PR TITLE
Allow Usage of FMC Maintained Network Object Groups in FW Rules

### DIFF
--- a/fmc/data_source_fmc_network_group_objects.go
+++ b/fmc/data_source_fmc_network_group_objects.go
@@ -12,9 +12,13 @@ func dataSourceFmcNetworkGroupObjects() *schema.Resource {
 		Description: "Data source for Network Group Objects in FMC\n\n" +
 			"An example is shown below: \n" +
 			"```hcl\n" +
-			"data \"fmc_network_group_objects\" \"test\" {\n" +
-			"	name = \"test-object\"\n" +
-			"}\n" +
+			"resource \"fmc_network_group_objects\" \"PrivateGroup\" {\n" +
+			"  name = \"PrivateGroup\"\n" +
+			"  description = \"Terraform private group\"\n" +
+			"  objects {\n" +
+			"      id = data.fmc_network_objects.PrivateVLAN.id\n" +
+			"      type = data.fmc_network_objects.PrivateVLAN.type\n" +
+			"  }\n" +
 			"```",
 
 		ReadContext: dataSourceNetworkGroupObjectsRead,
@@ -24,6 +28,19 @@ func dataSourceFmcNetworkGroupObjects() *schema.Resource {
 				Required:    true,
 				Description: "Name of the network group object",
 			},
+			// added code here
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of this resource",
+			},	
+
+			// added code here
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of this resource",
+			},			
 		},
 	}
 }
@@ -50,6 +67,15 @@ func dataSourceNetworkGroupObjectsRead(ctx context.Context, d *schema.ResourceDa
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "unable to get network group object",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+	// added code here
+	if err := d.Set("type", ifc.Type); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "unable to read network group object",
 			Detail:   err.Error(),
 		})
 		return diags

--- a/fmc/data_source_fmc_network_group_objects.go
+++ b/fmc/data_source_fmc_network_group_objects.go
@@ -14,11 +14,6 @@ func dataSourceFmcNetworkGroupObjects() *schema.Resource {
 			"```hcl\n" +
 			"resource \"fmc_network_group_objects\" \"PrivateGroup\" {\n" +
 			"  name = \"PrivateGroup\"\n" +
-			"  description = \"Terraform private group\"\n" +
-			"  objects {\n" +
-			"      id = data.fmc_network_objects.PrivateVLAN.id\n" +
-			"      type = data.fmc_network_objects.PrivateVLAN.type\n" +
-			"  }\n" +
 			"```",
 
 		ReadContext: dataSourceNetworkGroupObjectsRead,
@@ -28,18 +23,17 @@ func dataSourceFmcNetworkGroupObjects() *schema.Resource {
 				Required:    true,
 				Description: "Name of the network group object",
 			},
-			// added code here
+
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The id of this resource",
+				Description: "The id of the network group object",
 			},	
 
-			// added code here
 			"type": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The type of this resource",
+				Description: "The type of the network group object",
 			},			
 		},
 	}
@@ -71,7 +65,7 @@ func dataSourceNetworkGroupObjectsRead(ctx context.Context, d *schema.ResourceDa
 		})
 		return diags
 	}
-	// added code here
+
 	if err := d.Set("type", ifc.Type); err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/fmc/data_source_fmc_network_group_objects.go
+++ b/fmc/data_source_fmc_network_group_objects.go
@@ -12,8 +12,9 @@ func dataSourceFmcNetworkGroupObjects() *schema.Resource {
 		Description: "Data source for Network Group Objects in FMC\n\n" +
 			"An example is shown below: \n" +
 			"```hcl\n" +
-			"resource \"fmc_network_group_objects\" \"PrivateGroup\" {\n" +
-			"  name = \"PrivateGroup\"\n" +
+			"data \"fmc_network_group_objects\" \"test\" {\n" +
+			"	name = \"test-object\"\n" +
+			"}\n" +
 			"```",
 
 		ReadContext: dataSourceNetworkGroupObjectsRead,


### PR DESCRIPTION
This MR gathers the `type` attribute of the data port group object. This attribute, in combination with the id attribute, is required in order to use the port group object data source inside of the fmc_access_policy resource. 