### PR TITLE
Fix URL parameter concatenation for fmc_access_rule. Fixes #165

### DIFF
--- a/fmc/fmc_access_rule.go
+++ b/fmc/fmc_access_rule.go
@@ -157,8 +157,12 @@ func (v *Client) CreateFmcAccessRule(ctx context.Context, acpId, section, insert
 		initialSet = true
 	}
 	if category != "" {
-		url = fmt.Sprintf("%s?category=%s", url, category)
-		initialSet = true
+		if initialSet {
+			url = fmt.Sprintf("%s&category=%s", url, category)
+		} else {
+			url = fmt.Sprintf("%s?category=%s", url, category)
+			initialSet = true
+		}
 	}
 	if insertBefore != "" {
 		if initialSet {


### PR DESCRIPTION
Changes code so the category URL parameter will properly reference the initalSet variable. Fix for issue #165 