### PR TITLE
Add missing `type` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-beta2 (Unreleased)
+
+- (Fix) Align fields in ipv4/ipv6/vrf_ipv4/vrf_ipv6 static_route resources
+- (Enhancement) Add `type` field to multiple resources
+
 ## 2.0.0-beta1
 
 - Initial release

--- a/docs/data-sources/access_control_policy.md
+++ b/docs/data-sources/access_control_policy.md
@@ -43,6 +43,7 @@ data "fmc_access_control_policy" "example" {
 - `description` (String) Description of the Access Control Policy.
 - `prefilter_policy_id` (String) Id of the Prefilter Policy.
 - `rules` (Attributes List) Ordered list of Access Rules. Rules must be sorted in the order of the corresponding categories, if they have `category_name`. Uncategorized non-mandatory rules must be below all other rules. (see [below for nested schema](#nestedatt--rules))
+- `type` (String) Type of the object; this value is always 'AccessPolicy'.
 
 <a id="nestedatt--categories"></a>
 ### Nested Schema for `categories`

--- a/docs/data-sources/device_ipv4_static_route.md
+++ b/docs/data-sources/device_ipv4_static_route.md
@@ -40,6 +40,7 @@ data "fmc_device_ipv4_static_route" "example" {
 - `interface_logical_name` (String) Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin network 'any-ipv4'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
 - `metric_value` (Number) The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.
+- `type` (String) Type of the object; this value is always 'IPv4StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/data-sources/device_ipv6_static_route.md
+++ b/docs/data-sources/device_ipv6_static_route.md
@@ -34,12 +34,13 @@ data "fmc_device_ipv6_static_route" "example" {
 ### Read-Only
 
 - `destination_networks` (Attributes Set) Set of the destination networks matching this route (Host, Networks or Ranges). (see [below for nested schema](#nestedatt--destination_networks))
-- `gateway_literal` (String) The next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
-- `gateway_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
+- `gateway_host_literal` (String) The next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
+- `gateway_host_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `interface_id` (String) Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).
 - `interface_logical_name` (String) Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin host 'any-ipv6'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
 - `metric_value` (Number) The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.
+- `type` (String) Type of the object; this value is always 'IPv6StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/data-sources/device_vrf_ipv4_static_route.md
+++ b/docs/data-sources/device_vrf_ipv4_static_route.md
@@ -36,12 +36,13 @@ data "fmc_device_vrf_ipv4_static_route" "example" {
 ### Read-Only
 
 - `destination_networks` (Attributes Set) Set of the destination networks matching this route (Host, Networks or Ranges). (see [below for nested schema](#nestedatt--destination_networks))
-- `gateway_host_literal` (String) Next hop for this route as a literal IPv4 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
+- `gateway_host_literal` (String) Next hop for this route as a literal IPv4 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `gateway_host_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `interface_id` (String) Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).
 - `interface_logical_name` (String) Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin network 'any-ipv4'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
 - `metric_value` (Number) The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.
+- `type` (String) Type of the object; this value is always 'IPv4StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/data-sources/device_vrf_ipv6_static_route.md
+++ b/docs/data-sources/device_vrf_ipv6_static_route.md
@@ -36,12 +36,13 @@ data "fmc_device_vrf_ipv6_static_route" "example" {
 ### Read-Only
 
 - `destination_networks` (Attributes Set) Set of the destination networks matching this route (Host, Networks or Ranges). (see [below for nested schema](#nestedatt--destination_networks))
-- `gateway_literal` (String) Next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
-- `gateway_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
+- `gateway_host_literal` (String) Next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
+- `gateway_host_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `interface_id` (String) Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).
 - `interface_logical_name` (String) Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin host 'any-ipv6'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
 - `metric_value` (Number) The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.
+- `type` (String) Type of the object; this value is always 'IPv6StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/data-sources/extended_acl.md
+++ b/docs/data-sources/extended_acl.md
@@ -31,6 +31,7 @@ data "fmc_extended_acl" "example" {
 
 - `description` (String) Description of the Extended ACL.
 - `entries` (Attributes List) Ordered list of ACL's entries. (see [below for nested schema](#nestedatt--entries))
+- `type` (String) Type of the object; this value is always 'ExtendedAccessList'.
 
 <a id="nestedatt--entries"></a>
 ### Nested Schema for `entries`

--- a/docs/data-sources/fqdn_object.md
+++ b/docs/data-sources/fqdn_object.md
@@ -33,3 +33,4 @@ data "fmc_fqdn_object" "example" {
 - `dns_resolution` (String) Type of DNS resolution.
 - `fqdn` (String) Fully Qualified Domain Name.
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'FQDN'.

--- a/docs/data-sources/ftd_nat_policy.md
+++ b/docs/data-sources/ftd_nat_policy.md
@@ -32,6 +32,7 @@ data "fmc_ftd_nat_policy" "example" {
 - `auto_nat_rules` (Attributes List) The list of auto NAT rules. (see [below for nested schema](#nestedatt--auto_nat_rules))
 - `description` (String) Description of the object.
 - `manual_nat_rules` (Attributes List) The ordered list of manual NAT rules. (see [below for nested schema](#nestedatt--manual_nat_rules))
+- `type` (String) Type of the object; this value is always 'FTDNatPolicy'.
 
 <a id="nestedatt--auto_nat_rules"></a>
 ### Nested Schema for `auto_nat_rules`

--- a/docs/data-sources/icmpv4_object.md
+++ b/docs/data-sources/icmpv4_object.md
@@ -33,4 +33,4 @@ data "fmc_icmpv4_object" "example" {
 - `description` (String) Description of the object.
 - `icmp_type` (Number) ICMPv4 [type number](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml).
 - `overridable` (Boolean) Indicates whether object values can be overridden.
-- `type` (String)
+- `type` (String) Type of the object; this value is always 'ICMPV4Object'.

--- a/docs/data-sources/icmpv4_objects.md
+++ b/docs/data-sources/icmpv4_objects.md
@@ -43,4 +43,4 @@ Read-Only:
 - `icmp_type` (Number) ICMPv4 [type number](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml).
 - `id` (String) Id of the managed ICMPv4 object.
 - `overridable` (Boolean) Indicates whether object values can be overridden.
-- `type` (String)
+- `type` (String) Type of the object; this value is always 'ICMPV4Object'.

--- a/docs/data-sources/icmpv6_object.md
+++ b/docs/data-sources/icmpv6_object.md
@@ -33,3 +33,4 @@ data "fmc_icmpv6_object" "example" {
 - `description` (String) Description of the object.
 - `icmp_type` (Number) ICMPv6 [type number](https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml).
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'ICMPV6Object'.

--- a/docs/data-sources/interface_group.md
+++ b/docs/data-sources/interface_group.md
@@ -31,6 +31,7 @@ data "fmc_interface_group" "example" {
 
 - `interface_mode` (String) All interfaces' types must match the interface mode.
 - `interfaces` (Attributes Set) (see [below for nested schema](#nestedatt--interfaces))
+- `type` (String) Type of the object; this value is always 'InterfaceGroup'.
 
 <a id="nestedatt--interfaces"></a>
 ### Nested Schema for `interfaces`

--- a/docs/data-sources/intrusion_policy.md
+++ b/docs/data-sources/intrusion_policy.md
@@ -32,3 +32,4 @@ data "fmc_intrusion_policy" "example" {
 - `base_policy_id` (String) Id of the base policy.
 - `description` (String) Description of the policy.
 - `inspection_mode` (String) Inspection mode.
+- `type` (String) Type of the object; this value is always 'intrusionpolicy'.

--- a/docs/data-sources/network_analysis_policy.md
+++ b/docs/data-sources/network_analysis_policy.md
@@ -32,3 +32,4 @@ data "fmc_network_analysis_policy" "example" {
 - `base_policy_id` (String) Id of the base policy.
 - `description` (String) Description of the policy.
 - `inspection_mode` (String) Inspection mode.
+- `type` (String) Type of the object; this value is always 'NetworkAnalysisPolicy'.

--- a/docs/data-sources/network_group.md
+++ b/docs/data-sources/network_group.md
@@ -33,6 +33,7 @@ data "fmc_network_group" "example" {
 - `literals` (Attributes Set) Set of literal values (Host or Network). (see [below for nested schema](#nestedatt--literals))
 - `objects` (Attributes Set) Set of network objects (Host, Network, Range, FQDN or Network Group). (see [below for nested schema](#nestedatt--objects))
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'NetworkGroup'.
 
 <a id="nestedatt--literals"></a>
 ### Nested Schema for `literals`

--- a/docs/data-sources/port.md
+++ b/docs/data-sources/port.md
@@ -33,3 +33,4 @@ data "fmc_port" "example" {
 - `overridable` (Boolean) Indicates whether object values can be overridden.
 - `port` (String) Port number in decimal for TCP or UDP. Otherwise a protocol-specific value.
 - `protocol` (String) IANA protocol number or Ethertype. This is handled differently for Transport and Network layer protocols. Transport layer protocols are identified by the IANA protocol number (e.g. 6 means TCP, and 17 means UDP). Network layer protocols are identified by the decimal form of the IEEE Registration Authority Ethertype (e.g. 2048 means IP).
+- `type` (String) Type of the object; this value is always 'ProtocolPortObject'.

--- a/docs/data-sources/range.md
+++ b/docs/data-sources/range.md
@@ -32,3 +32,4 @@ data "fmc_range" "example" {
 - `description` (String) Optional user-created description.
 - `ip_range` (String) Range of addresses, IPv4 or IPv6.
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'Range'.

--- a/docs/data-sources/standard_acl.md
+++ b/docs/data-sources/standard_acl.md
@@ -31,6 +31,7 @@ data "fmc_standard_acl" "example" {
 
 - `description` (String) Description of the object.
 - `entries` (Attributes List) Ordered list of ACL's entries. (see [below for nested schema](#nestedatt--entries))
+- `type` (String) Type of the object; this value is always 'StandardAccessList'.
 
 <a id="nestedatt--entries"></a>
 ### Nested Schema for `entries`

--- a/docs/data-sources/url.md
+++ b/docs/data-sources/url.md
@@ -31,4 +31,5 @@ data "fmc_url" "example" {
 
 - `description` (String) Description of the object.
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'Url'.
 - `url` (String) URL value.

--- a/docs/data-sources/url_group.md
+++ b/docs/data-sources/url_group.md
@@ -32,6 +32,7 @@ data "fmc_url_group" "example" {
 - `description` (String) Description of the object.
 - `literals` (Attributes Set) Set of literal values to be included in the URL group. (see [below for nested schema](#nestedatt--literals))
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'UrlGroup'.
 - `urls` (Attributes Set) Set of URL objects to be included in the URL group. (see [below for nested schema](#nestedatt--urls))
 
 <a id="nestedatt--literals"></a>

--- a/docs/data-sources/url_groups.md
+++ b/docs/data-sources/url_groups.md
@@ -42,6 +42,7 @@ Read-Only:
 - `id` (String) Id of the managed URL Group.
 - `literals` (Attributes Set) Set of literal values to be included in the URL group. (see [below for nested schema](#nestedatt--items--literals))
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'UrlGroup'.
 - `urls` (Attributes Set) Set of URL objects to be included in the URL group. (see [below for nested schema](#nestedatt--items--urls))
 
 <a id="nestedatt--items--literals"></a>

--- a/docs/data-sources/urls.md
+++ b/docs/data-sources/urls.md
@@ -41,4 +41,5 @@ Read-Only:
 - `description` (String) Description of the object.
 - `id` (String) Id of the managed URL object.
 - `overridable` (Boolean) Indicates whether object values can be overridden.
+- `type` (String) Type of the object; this value is always 'Url'.
 - `url` (String) URL value.

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,11 @@ description: |-
 
 # Changelog
 
+## 2.0.0-beta2
+
+- (Enhancement) Add `type` field to multiple resources
+- (Fix) Align fields in ipv4/ipv6/vrf_ipv4/vrf_ipv6 static_route resources
+
 ## 2.0.0-beta1
 
 - Initial release

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,10 +7,10 @@ description: |-
 
 # Changelog
 
-## 2.0.0-beta2
+## 2.0.0-beta2 (Unreleased)
 
-- (Enhancement) Add `type` field to multiple resources
 - (Fix) Align fields in ipv4/ipv6/vrf_ipv4/vrf_ipv6 static_route resources
+- (Enhancement) Add `type` field to multiple resources
 
 ## 2.0.0-beta1
 

--- a/docs/resources/access_control_policy.md
+++ b/docs/resources/access_control_policy.md
@@ -186,6 +186,7 @@ resource "fmc_access_control_policy" "example" {
 
 - `default_action_id` (String) Id of the default action.
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'AccessPolicy'.
 
 <a id="nestedatt--categories"></a>
 ### Nested Schema for `categories`

--- a/docs/resources/device_ipv4_static_route.md
+++ b/docs/resources/device_ipv4_static_route.md
@@ -50,6 +50,7 @@ resource "fmc_device_ipv4_static_route" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'IPv4StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/resources/device_ipv6_static_route.md
+++ b/docs/resources/device_ipv6_static_route.md
@@ -22,8 +22,8 @@ resource "fmc_device_ipv6_static_route" "example" {
       id = "76d24097-41c4-4558-a4d0-a8c07ac08470"
     }
   ]
-  metric_value    = 254
-  gateway_literal = "2024::1"
+  metric_value         = 254
+  gateway_host_literal = "2024::1"
 }
 ```
 
@@ -40,8 +40,8 @@ resource "fmc_device_ipv6_static_route" "example" {
 ### Optional
 
 - `domain` (String) Name of the FMC domain
-- `gateway_literal` (String) The next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
-- `gateway_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
+- `gateway_host_literal` (String) The next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
+- `gateway_host_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin host 'any-ipv6'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
   - Default value: `false`
 - `metric_value` (Number) The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.
@@ -50,6 +50,7 @@ resource "fmc_device_ipv6_static_route" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'IPv6StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/resources/device_vrf_ipv4_static_route.md
+++ b/docs/resources/device_vrf_ipv4_static_route.md
@@ -42,7 +42,7 @@ resource "fmc_device_vrf_ipv4_static_route" "example" {
 ### Optional
 
 - `domain` (String) Name of the FMC domain
-- `gateway_host_literal` (String) Next hop for this route as a literal IPv4 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
+- `gateway_host_literal` (String) Next hop for this route as a literal IPv4 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `gateway_host_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin network 'any-ipv4'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
   - Default value: `false`
@@ -52,6 +52,7 @@ resource "fmc_device_vrf_ipv4_static_route" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'IPv4StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/resources/device_vrf_ipv6_static_route.md
+++ b/docs/resources/device_vrf_ipv6_static_route.md
@@ -23,8 +23,8 @@ resource "fmc_device_vrf_ipv6_static_route" "example" {
       id = "76d24097-41c4-4558-a4d0-a8c07ac08470"
     }
   ]
-  metric_value    = 254
-  gateway_literal = "2024::1"
+  metric_value         = 254
+  gateway_host_literal = "2024::1"
 }
 ```
 
@@ -42,8 +42,8 @@ resource "fmc_device_vrf_ipv6_static_route" "example" {
 ### Optional
 
 - `domain` (String) Name of the FMC domain
-- `gateway_literal` (String) Next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
-- `gateway_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.
+- `gateway_host_literal` (String) Next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
+- `gateway_host_object_id` (String) Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.
 - `is_tunneled` (Boolean) Indicates whether this route is a separate default route for VPN traffic. Should be used for default route only (such as when the destination_networks points to a builtin host 'any-ipv6'). Useful if you want VPN traffic to use a different default route than non-VPN traffic. When a tunnel terminates on the device, all traffic from it that cannot be routed using learned or static routes is sent to this route. You can configure only one default tunneled gateway per device. ECMP for tunneled traffic is not supported. This attribute conflicts with `metric_value` attribute.
   - Default value: `false`
 - `metric_value` (Number) The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.
@@ -52,6 +52,7 @@ resource "fmc_device_vrf_ipv6_static_route" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'IPv6StaticRoute'.
 
 <a id="nestedatt--destination_networks"></a>
 ### Nested Schema for `destination_networks`

--- a/docs/resources/extended_acl.md
+++ b/docs/resources/extended_acl.md
@@ -104,6 +104,7 @@ resource "fmc_extended_acl" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'ExtendedAccessList'.
 
 <a id="nestedatt--entries"></a>
 ### Nested Schema for `entries`

--- a/docs/resources/fqdn_object.md
+++ b/docs/resources/fqdn_object.md
@@ -41,6 +41,7 @@ resource "fmc_fqdn_object" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'FQDN'.
 
 ## Import
 

--- a/docs/resources/fqdn_objects.md
+++ b/docs/resources/fqdn_objects.md
@@ -60,12 +60,11 @@ Optional:
   - Choices: `IPV4_ONLY`, `IPV6_ONLY`, `IPV4_AND_IPV6`
   - Default value: `IPV4_AND_IPV6`
 - `overridable` (Boolean) Indicates whether object values can be overridden.
-- `type` (String) Type of the object; this value is always 'FQDN'.
-  - Default value: `FQDN`
 
 Read-Only:
 
 - `id` (String) Id of the managed object.
+- `type` (String) Type of the object; this value is always 'FQDN'.
 
 ## Import
 

--- a/docs/resources/ftd_nat_policy.md
+++ b/docs/resources/ftd_nat_policy.md
@@ -54,6 +54,7 @@ resource "fmc_ftd_nat_policy" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'FTDNatPolicy'.
 
 <a id="nestedatt--auto_nat_rules"></a>
 ### Nested Schema for `auto_nat_rules`

--- a/docs/resources/icmpv4_object.md
+++ b/docs/resources/icmpv4_object.md
@@ -41,7 +41,7 @@ resource "fmc_icmpv4_object" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
-- `type` (String)
+- `type` (String) Type of the object; this value is always 'ICMPV4Object'.
 
 ## Import
 

--- a/docs/resources/icmpv4_objects.md
+++ b/docs/resources/icmpv4_objects.md
@@ -61,7 +61,7 @@ Optional:
 Read-Only:
 
 - `id` (String) Id of the managed ICMPv4 object.
-- `type` (String)
+- `type` (String) Type of the object; this value is always 'ICMPV4Object'.
 
 ## Import
 

--- a/docs/resources/icmpv6_object.md
+++ b/docs/resources/icmpv6_object.md
@@ -41,6 +41,7 @@ resource "fmc_icmpv6_object" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'ICMPV6Object'.
 
 ## Import
 

--- a/docs/resources/interface_group.md
+++ b/docs/resources/interface_group.md
@@ -41,6 +41,7 @@ resource "fmc_interface_group" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'InterfaceGroup'.
 
 <a id="nestedatt--interfaces"></a>
 ### Nested Schema for `interfaces`

--- a/docs/resources/intrusion_policy.md
+++ b/docs/resources/intrusion_policy.md
@@ -39,6 +39,7 @@ resource "fmc_intrusion_policy" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'intrusionpolicy'.
 
 ## Import
 

--- a/docs/resources/network_analysis_policy.md
+++ b/docs/resources/network_analysis_policy.md
@@ -39,6 +39,7 @@ resource "fmc_network_analysis_policy" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'NetworkAnalysisPolicy'.
 
 ## Import
 

--- a/docs/resources/network_group.md
+++ b/docs/resources/network_group.md
@@ -47,6 +47,7 @@ resource "fmc_network_group" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'NetworkGroup'.
 
 <a id="nestedatt--literals"></a>
 ### Nested Schema for `literals`

--- a/docs/resources/network_groups.md
+++ b/docs/resources/network_groups.md
@@ -58,6 +58,7 @@ Optional:
 Read-Only:
 
 - `id` (String) Id of the managed Network Group.
+- `type` (String) Type of the object; this value is always 'NetworkGroup'.
 
 <a id="nestedatt--items--literals"></a>
 ### Nested Schema for `items.literals`

--- a/docs/resources/port.md
+++ b/docs/resources/port.md
@@ -39,6 +39,7 @@ resource "fmc_port" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'ProtocolPortObject'.
 
 ## Import
 

--- a/docs/resources/range.md
+++ b/docs/resources/range.md
@@ -37,6 +37,7 @@ resource "fmc_range" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'Range'.
 
 ## Import
 

--- a/docs/resources/standard_acl.md
+++ b/docs/resources/standard_acl.md
@@ -55,6 +55,7 @@ resource "fmc_standard_acl" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'StandardAccessList'.
 
 <a id="nestedatt--entries"></a>
 ### Nested Schema for `entries`

--- a/docs/resources/url.md
+++ b/docs/resources/url.md
@@ -37,6 +37,7 @@ resource "fmc_url" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'Url'.
 
 ## Import
 

--- a/docs/resources/url_group.md
+++ b/docs/resources/url_group.md
@@ -47,6 +47,7 @@ resource "fmc_url_group" "example" {
 ### Read-Only
 
 - `id` (String) Id of the object
+- `type` (String) Type of the object; this value is always 'UrlGroup'.
 
 <a id="nestedatt--urls"></a>
 ### Nested Schema for `urls`

--- a/docs/resources/url_groups.md
+++ b/docs/resources/url_groups.md
@@ -70,6 +70,7 @@ Optional:
 Read-Only:
 
 - `id` (String) Id of the managed URL Group.
+- `type` (String) Type of the object; this value is always 'UrlGroup'.
 
 <a id="nestedatt--items--urls"></a>
 ### Nested Schema for `items.urls`

--- a/docs/resources/urls.md
+++ b/docs/resources/urls.md
@@ -60,6 +60,7 @@ Optional:
 Read-Only:
 
 - `id` (String) Id of the managed URL object.
+- `type` (String) Type of the object; this value is always 'Url'.
 
 ## Import
 

--- a/examples/resources/fmc_device_ipv6_static_route/resource.tf
+++ b/examples/resources/fmc_device_ipv6_static_route/resource.tf
@@ -7,6 +7,6 @@ resource "fmc_device_ipv6_static_route" "example" {
       id = "76d24097-41c4-4558-a4d0-a8c07ac08470"
     }
   ]
-  metric_value    = 254
-  gateway_literal = "2024::1"
+  metric_value         = 254
+  gateway_host_literal = "2024::1"
 }

--- a/examples/resources/fmc_device_vrf_ipv6_static_route/resource.tf
+++ b/examples/resources/fmc_device_vrf_ipv6_static_route/resource.tf
@@ -8,6 +8,6 @@ resource "fmc_device_vrf_ipv6_static_route" "example" {
       id = "76d24097-41c4-4558-a4d0-a8c07ac08470"
     }
   ]
-  metric_value    = 254
-  gateway_literal = "2024::1"
+  metric_value         = 254
+  gateway_host_literal = "2024::1"
 }

--- a/gen/definitions/access_control_policy.yaml
+++ b/gen/definitions/access_control_policy.yaml
@@ -10,6 +10,10 @@ attributes:
     description: Name of the Access Control Policy.
     example: my_access_control_policy
     data_source_query: true
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'AccessPolicy'.
+    computed: true
   - model_name: description
     type: String
     description: Description of the Access Control Policy.

--- a/gen/definitions/device_ipv4_static_route.yaml
+++ b/gen/definitions/device_ipv4_static_route.yaml
@@ -20,6 +20,10 @@ attributes:
     mandatory: true
     example: myinterface-0-1
     test_value: fmc_device_physical_interface.test.logical_name
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'IPv4StaticRoute'.
+    computed: true
   - model_name: parent # dummy
     data_path: [links]
     tf_name: interface_id

--- a/gen/definitions/device_ipv6_static_route.yaml
+++ b/gen/definitions/device_ipv6_static_route.yaml
@@ -20,6 +20,10 @@ attributes:
     mandatory: true
     example: myinterface-0-1
     test_value: fmc_device_physical_interface.test.logical_name
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'IPv6StaticRoute'.
+    computed: true
   - model_name: parent # dummy
     data_path: [links]
     tf_name: interface_id
@@ -58,20 +62,20 @@ attributes:
     test_value: "null"
   - model_name: id
     data_path: [gateway, object]
-    tf_name: gateway_object_id
+    tf_name: gateway_host_object_id
     description: >-
-      Id of the next hop for this route. Exactly one of `gateway_object_id`
-      or `gateway_literal` must be present.
+      Id of the next hop for this route. Exactly one of `gateway_host_object_id`
+      or `gateway_host_literal` must be present.
     type: String
     exclude_example: true
     exclude_test: true
   - model_name: value
     data_path: [gateway, literal]
-    tf_name: gateway_literal
+    tf_name: gateway_host_literal
     type: String
     description: >-
-      The next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id`
-      or `gateway_literal` must be present.
+      The next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id`
+      or `gateway_host_literal` must be present.
     example: 2024::1
     minimum_test_value: '"2024::2"'
   - model_name: isTunneled

--- a/gen/definitions/device_vrf_ipv4_static_route.yaml
+++ b/gen/definitions/device_vrf_ipv4_static_route.yaml
@@ -26,6 +26,10 @@ attributes:
     mandatory: true
     example: myinterface-0-1
     test_value: fmc_device_physical_interface.test.logical_name
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'IPv4StaticRoute'.
+    computed: true
   - model_name: parent # dummy
     data_path: [links]
     tf_name: interface_id
@@ -76,8 +80,8 @@ attributes:
     tf_name: gateway_host_literal
     type: String
     description: >-
-      Next hop for this route as a literal IPv4 address. Exactly one of `gateway_object_id`
-      or `gateway_literal` must be present.
+      Next hop for this route as a literal IPv4 address. Exactly one of `gateway_host_object_id`
+      or `gateway_host_literal` must be present.
     example: 10.0.0.1
     exclude_test: true
   - model_name: isTunneled

--- a/gen/definitions/device_vrf_ipv6_static_route.yaml
+++ b/gen/definitions/device_vrf_ipv6_static_route.yaml
@@ -26,6 +26,10 @@ attributes:
     mandatory: true
     example: myinterface-0-1
     test_value: fmc_device_physical_interface.test.logical_name
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'IPv6StaticRoute'.
+    computed: true
   - model_name: parent # dummy
     data_path: [links]
     tf_name: interface_id
@@ -64,20 +68,20 @@ attributes:
     test_value: "null"
   - model_name: id
     data_path: [gateway, object]
-    tf_name: gateway_object_id
+    tf_name: gateway_host_object_id
     description: >-
-      Id of the next hop for this route. Exactly one of `gateway_object_id`
-      or `gateway_literal` must be present.
+      Id of the next hop for this route. Exactly one of `gateway_host_object_id`
+      or `gateway_host_literal` must be present.
     type: String
     exclude_example: true
     exclude_test: true
   - model_name: value
     data_path: [gateway, literal]
-    tf_name: gateway_literal
+    tf_name: gateway_host_literal
     type: String
     description: >-
-      Next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id`
-      or `gateway_literal` must be present.
+      Next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id`
+      or `gateway_host_literal` must be present.
     example: 2024::1
     exclude_test: true
   - model_name: isTunneled

--- a/gen/definitions/extended_acl.yaml
+++ b/gen/definitions/extended_acl.yaml
@@ -14,6 +14,10 @@ attributes:
     type: String
     description: Description of the Extended ACL.
     example: "My Extended Access Control List"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'ExtendedAccessList'.
+    computed: true
   - model_name: entries
     type: List
     description: Ordered list of ACL's entries.

--- a/gen/definitions/fqdn_object.yaml
+++ b/gen/definitions/fqdn_object.yaml
@@ -30,3 +30,7 @@ attributes:
     description: Indicates whether object values can be overridden.
     exclude_example: true
     test_value: "true"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'FQDN'.
+    computed: true

--- a/gen/definitions/fqdn_objects.yaml
+++ b/gen/definitions/fqdn_objects.yaml
@@ -43,6 +43,4 @@ attributes:
       - model_name: type
         type: String
         description: Type of the object; this value is always 'FQDN'.
-        default_value: FQDN
-        exclude_example: true
-        exclude_test: true
+        computed: true

--- a/gen/definitions/ftd_nat_policy.yaml
+++ b/gen/definitions/ftd_nat_policy.yaml
@@ -14,6 +14,10 @@ attributes:
     type: String
     description: Description of the object.
     example: My nat policy
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'FTDNatPolicy'.
+    computed: true
   - model_name: dummy_manual_nat_rules
     tf_name: manual_nat_rules
     type: List

--- a/gen/definitions/icmpv4_object.yaml
+++ b/gen/definitions/icmpv4_object.yaml
@@ -34,4 +34,5 @@ attributes:
     test_value: "true"
   - model_name: type
     type: String
+    description: Type of the object; this value is always 'ICMPV4Object'.
     computed: true

--- a/gen/definitions/icmpv4_objects.yaml
+++ b/gen/definitions/icmpv4_objects.yaml
@@ -43,4 +43,5 @@ attributes:
         example: "0"
       - model_name: type
         type: String
+        description: Type of the object; this value is always 'ICMPV4Object'.
         computed: true

--- a/gen/definitions/icmpv6_object.yaml
+++ b/gen/definitions/icmpv6_object.yaml
@@ -32,3 +32,7 @@ attributes:
     description: Indicates whether object values can be overridden.
     exclude_example: true
     test_value: "true"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'ICMPV6Object'.
+    computed: true

--- a/gen/definitions/interface_group.yaml
+++ b/gen/definitions/interface_group.yaml
@@ -16,6 +16,10 @@ attributes:
     enum_values: [INLINE, SWITCHED, ROUTED]
     mandatory: true
     example: ROUTED
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'InterfaceGroup'.
+    computed: true
   - model_name: interfaces
     type: Set
     attributes:

--- a/gen/definitions/intrusion_policy.yaml
+++ b/gen/definitions/intrusion_policy.yaml
@@ -13,6 +13,10 @@ attributes:
     type: String
     description: Description of the policy.
     example: "My IPS Policy"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'intrusionpolicy'.
+    computed: true
   - model_name: id
     data_path: [basePolicy]
     tf_name: base_policy_id

--- a/gen/definitions/network_analysis_policy.yaml
+++ b/gen/definitions/network_analysis_policy.yaml
@@ -13,6 +13,10 @@ attributes:
     type: String
     description: Description of the policy.
     example: "My network analysis policy"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'NetworkAnalysisPolicy'.
+    computed: true
   - model_name: id
     data_path: [basePolicy]
     tf_name: base_policy_id

--- a/gen/definitions/network_group.yaml
+++ b/gen/definitions/network_group.yaml
@@ -13,6 +13,10 @@ attributes:
     type: String
     description: Description of the ojbect.
     example: "My Network Group 1"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'NetworkGroup'.
+    computed: true
   - model_name: overridable
     type: Bool
     description: Indicates whether object values can be overridden.

--- a/gen/definitions/network_groups.yaml
+++ b/gen/definitions/network_groups.yaml
@@ -21,6 +21,10 @@ attributes:
         type: String
         description: Description of the object.
         example: "My Network Group 1"
+      - model_name: type
+        type: String
+        description: Type of the object; this value is always 'NetworkGroup'.
+        computed: true
       - model_name: overridable
         type: Bool
         description: Indicates whether object values can be overridden.

--- a/gen/definitions/port.yaml
+++ b/gen/definitions/port.yaml
@@ -32,3 +32,7 @@ attributes:
     description: Indicates whether object values can be overridden.
     exclude_example: true
     test_value: "true"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'ProtocolPortObject'.
+    computed: true

--- a/gen/definitions/range.yaml
+++ b/gen/definitions/range.yaml
@@ -24,3 +24,7 @@ attributes:
     description: Indicates whether object values can be overridden.
     exclude_example: true
     test_value: "true"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'Range'.
+    computed: true

--- a/gen/definitions/standard_acl.yaml
+++ b/gen/definitions/standard_acl.yaml
@@ -14,6 +14,10 @@ attributes:
     type: String
     description: Description of the object.
     example: "My standard ACL"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'StandardAccessList'.
+    computed: true
   - model_name: entries
     type: List
     description: Ordered list of ACL's entries.

--- a/gen/definitions/url.yaml
+++ b/gen/definitions/url.yaml
@@ -23,3 +23,7 @@ attributes:
     description: Indicates whether object values can be overridden.
     exclude_example: true
     test_value: "true"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'Url'.
+    computed: true

--- a/gen/definitions/url_group.yaml
+++ b/gen/definitions/url_group.yaml
@@ -13,6 +13,10 @@ attributes:
     type: String
     description: Description of the object.
     example: "My URL group"
+  - model_name: type
+    type: String
+    description: Type of the object; this value is always 'UrlGroup'.
+    computed: true
   - model_name: overridable
     type: Bool
     description: Indicates whether object values can be overridden.

--- a/gen/definitions/url_groups.yaml
+++ b/gen/definitions/url_groups.yaml
@@ -22,6 +22,10 @@ attributes:
         type: String
         description: Description of the object.
         example: "My URL group"
+      - model_name: type
+        type: String
+        description: Type of the object; this value is always 'UrlGroup'.
+        computed: true
       - model_name: overridable
         type: Bool
         description: Indicates whether object values can be overridden.

--- a/gen/definitions/urls.yaml
+++ b/gen/definitions/urls.yaml
@@ -32,3 +32,7 @@ attributes:
         description: Indicates whether object values can be overridden.
         exclude_example: true
         test_value: "true"
+      - model_name: type
+        type: String
+        description: Type of the object; this value is always 'Url'.
+        computed: true

--- a/internal/provider/data_source_fmc_access_control_policy.go
+++ b/internal/provider/data_source_fmc_access_control_policy.go
@@ -77,6 +77,10 @@ func (d *AccessControlPolicyDataSource) Schema(ctx context.Context, req datasour
 				Optional:            true,
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'AccessPolicy'.",
+				Computed:            true,
+			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the Access Control Policy.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_access_control_policy_test.go
+++ b/internal/provider/data_source_fmc_access_control_policy_test.go
@@ -31,6 +31,7 @@ import (
 func TestAccDataSourceFmcAccessControlPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_access_control_policy.test", "name", "my_access_control_policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_access_control_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_access_control_policy.test", "description", "My Access Control Policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_access_control_policy.test", "default_action", "BLOCK"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_access_control_policy.test", "default_action_log_begin", "true"))

--- a/internal/provider/data_source_fmc_device_ipv4_static_route.go
+++ b/internal/provider/data_source_fmc_device_ipv4_static_route.go
@@ -74,6 +74,10 @@ func (d *DeviceIPv4StaticRouteDataSource) Schema(ctx context.Context, req dataso
 				MarkdownDescription: "Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'IPv4StaticRoute'.",
+				Computed:            true,
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_device_ipv4_static_route_test.go
+++ b/internal/provider/data_source_fmc_device_ipv4_static_route_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceFmcDeviceIPv4StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_device_ipv4_static_route.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_ipv4_static_route.test", "gateway_host_literal", "10.0.0.1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/data_source_fmc_device_ipv6_static_route.go
+++ b/internal/provider/data_source_fmc_device_ipv6_static_route.go
@@ -74,6 +74,10 @@ func (d *DeviceIPv6StaticRouteDataSource) Schema(ctx context.Context, req dataso
 				MarkdownDescription: "Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'IPv6StaticRoute'.",
+				Computed:            true,
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).",
 				Computed:            true,
@@ -94,12 +98,12 @@ func (d *DeviceIPv6StaticRouteDataSource) Schema(ctx context.Context, req dataso
 				MarkdownDescription: "The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.",
 				Computed:            true,
 			},
-			"gateway_object_id": schema.StringAttribute{
-				MarkdownDescription: "Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.",
+			"gateway_host_object_id": schema.StringAttribute{
+				MarkdownDescription: "Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.",
 				Computed:            true,
 			},
-			"gateway_literal": schema.StringAttribute{
-				MarkdownDescription: "The next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.",
+			"gateway_host_literal": schema.StringAttribute{
+				MarkdownDescription: "The next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.",
 				Computed:            true,
 			},
 			"is_tunneled": schema.BoolAttribute{

--- a/internal/provider/data_source_fmc_device_ipv6_static_route_test.go
+++ b/internal/provider/data_source_fmc_device_ipv6_static_route_test.go
@@ -34,7 +34,8 @@ func TestAccDataSourceFmcDeviceIPv6StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_ipv6_static_route.test", "gateway_literal", "2024::1"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_device_ipv6_static_route.test", "type"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_ipv6_static_route.test", "gateway_host_literal", "2024::1"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -81,7 +82,7 @@ func testAccDataSourceFmcDeviceIPv6StaticRouteConfig() string {
 	config += `		id = data.fmc_host.test.id` + "\n"
 	config += `	}]` + "\n"
 	config += `	metric_value = null` + "\n"
-	config += `	gateway_literal = "2024::1"` + "\n"
+	config += `	gateway_host_literal = "2024::1"` + "\n"
 	config += `	is_tunneled = true` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/data_source_fmc_device_vrf_ipv4_static_route.go
+++ b/internal/provider/data_source_fmc_device_vrf_ipv4_static_route.go
@@ -78,6 +78,10 @@ func (d *DeviceVRFIPv4StaticRouteDataSource) Schema(ctx context.Context, req dat
 				MarkdownDescription: "Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'IPv4StaticRoute'.",
+				Computed:            true,
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).",
 				Computed:            true,
@@ -103,7 +107,7 @@ func (d *DeviceVRFIPv4StaticRouteDataSource) Schema(ctx context.Context, req dat
 				Computed:            true,
 			},
 			"gateway_host_literal": schema.StringAttribute{
-				MarkdownDescription: "Next hop for this route as a literal IPv4 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.",
+				MarkdownDescription: "Next hop for this route as a literal IPv4 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.",
 				Computed:            true,
 			},
 			"is_tunneled": schema.BoolAttribute{

--- a/internal/provider/data_source_fmc_device_vrf_ipv4_static_route_test.go
+++ b/internal/provider/data_source_fmc_device_vrf_ipv4_static_route_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceFmcDeviceVRFIPv4StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_device_vrf_ipv4_static_route.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_device_vrf_ipv6_static_route.go
+++ b/internal/provider/data_source_fmc_device_vrf_ipv6_static_route.go
@@ -78,6 +78,10 @@ func (d *DeviceVRFIPv6StaticRouteDataSource) Schema(ctx context.Context, req dat
 				MarkdownDescription: "Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'IPv6StaticRoute'.",
+				Computed:            true,
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).",
 				Computed:            true,
@@ -98,12 +102,12 @@ func (d *DeviceVRFIPv6StaticRouteDataSource) Schema(ctx context.Context, req dat
 				MarkdownDescription: "The cost of the route. The metric is used to compare routes among different routing protocols. The default administrative distance for static routes is 1, giving it precedence over routes discovered by dynamic routing protocols but not directly connected routes.",
 				Computed:            true,
 			},
-			"gateway_object_id": schema.StringAttribute{
-				MarkdownDescription: "Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.",
+			"gateway_host_object_id": schema.StringAttribute{
+				MarkdownDescription: "Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.",
 				Computed:            true,
 			},
-			"gateway_literal": schema.StringAttribute{
-				MarkdownDescription: "Next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.",
+			"gateway_host_literal": schema.StringAttribute{
+				MarkdownDescription: "Next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.",
 				Computed:            true,
 			},
 			"is_tunneled": schema.BoolAttribute{

--- a/internal/provider/data_source_fmc_device_vrf_ipv6_static_route_test.go
+++ b/internal/provider/data_source_fmc_device_vrf_ipv6_static_route_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceFmcDeviceVRFIPv6StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_device_vrf_ipv6_static_route.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_extended_acl.go
+++ b/internal/provider/data_source_fmc_extended_acl.go
@@ -80,6 +80,10 @@ func (d *ExtendedACLDataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "Description of the Extended ACL.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'ExtendedAccessList'.",
+				Computed:            true,
+			},
 			"entries": schema.ListNestedAttribute{
 				MarkdownDescription: "Ordered list of ACL's entries.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_extended_acl_test.go
+++ b/internal/provider/data_source_fmc_extended_acl_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcExtendedACL(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_extended_acl.test", "name", "my_extended_acl"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_extended_acl.test", "description", "My Extended Access Control List"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_extended_acl.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_extended_acl.test", "entries.0.action", "DENY"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_extended_acl.test", "entries.0.log_level", "WARNING"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_extended_acl.test", "entries.0.logging", "PER_ACCESS_LIST_ENTRY"))

--- a/internal/provider/data_source_fmc_fqdn_object.go
+++ b/internal/provider/data_source_fmc_fqdn_object.go
@@ -92,6 +92,10 @@ func (d *FQDNObjectDataSource) Schema(ctx context.Context, req datasource.Schema
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'FQDN'.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_fmc_fqdn_object_test.go
+++ b/internal/provider/data_source_fmc_fqdn_object_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceFmcFQDNObject(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_fqdn_object.test", "fqdn", "www.example.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_fqdn_object.test", "dns_resolution", "IPV4_AND_IPV6"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_fqdn_object.test", "description", "My FQDN Object"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_fqdn_object.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_fqdn_objects_test.go
+++ b/internal/provider/data_source_fmc_fqdn_objects_test.go
@@ -35,6 +35,7 @@ func TestAccDataSourceFmcFQDNObjects(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_fqdn_objects.test", "items.my_fqdn_objects.overridable", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_fqdn_objects.test", "items.my_fqdn_objects.fqdn", "www.example.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_fqdn_objects.test", "items.my_fqdn_objects.dns_resolution", "IPV4_AND_IPV6"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_fqdn_objects.test", "items.my_fqdn_objects.type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_ftd_nat_policy.go
+++ b/internal/provider/data_source_fmc_ftd_nat_policy.go
@@ -81,6 +81,10 @@ func (d *FTDNATPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 				MarkdownDescription: "Description of the object.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'FTDNatPolicy'.",
+				Computed:            true,
+			},
 			"manual_nat_rules": schema.ListNestedAttribute{
 				MarkdownDescription: "The ordered list of manual NAT rules.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_ftd_nat_policy_test.go
+++ b/internal/provider/data_source_fmc_ftd_nat_policy_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcFTDNATPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_ftd_nat_policy.test", "name", "my_ftd_nat_policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_ftd_nat_policy.test", "description", "My nat policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_ftd_nat_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_ftd_nat_policy.test", "manual_nat_rules.0.description", "My manual nat rule 1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_ftd_nat_policy.test", "manual_nat_rules.0.enabled", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_ftd_nat_policy.test", "manual_nat_rules.0.section", "BEFORE_AUTO"))

--- a/internal/provider/data_source_fmc_icmpv4_object.go
+++ b/internal/provider/data_source_fmc_icmpv4_object.go
@@ -93,7 +93,7 @@ func (d *ICMPv4ObjectDataSource) Schema(ctx context.Context, req datasource.Sche
 				Computed:            true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "",
+				MarkdownDescription: "Type of the object; this value is always 'ICMPV4Object'.",
 				Computed:            true,
 			},
 		},

--- a/internal/provider/data_source_fmc_icmpv4_objects.go
+++ b/internal/provider/data_source_fmc_icmpv4_objects.go
@@ -92,7 +92,7 @@ func (d *ICMPv4ObjectsDataSource) Schema(ctx context.Context, req datasource.Sch
 							Computed:            true,
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: "",
+							MarkdownDescription: "Type of the object; this value is always 'ICMPV4Object'.",
 							Computed:            true,
 						},
 					},

--- a/internal/provider/data_source_fmc_icmpv6_object.go
+++ b/internal/provider/data_source_fmc_icmpv6_object.go
@@ -92,6 +92,10 @@ func (d *ICMPv6ObjectDataSource) Schema(ctx context.Context, req datasource.Sche
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'ICMPV6Object'.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_fmc_icmpv6_object_test.go
+++ b/internal/provider/data_source_fmc_icmpv6_object_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceFmcICMPv6Object(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_icmpv6_object.test", "code", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_icmpv6_object.test", "name", "my_icmpv6_object"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_icmpv6_object.test", "description", "ICMPv6 address unreachable response, type 1, code 3"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_icmpv6_object.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_interface_group.go
+++ b/internal/provider/data_source_fmc_interface_group.go
@@ -80,6 +80,10 @@ func (d *InterfaceGroupDataSource) Schema(ctx context.Context, req datasource.Sc
 				MarkdownDescription: "All interfaces' types must match the interface mode.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'InterfaceGroup'.",
+				Computed:            true,
+			},
 			"interfaces": schema.SetNestedAttribute{
 				MarkdownDescription: "",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_interface_group_test.go
+++ b/internal/provider/data_source_fmc_interface_group_test.go
@@ -36,6 +36,7 @@ func TestAccDataSourceFmcInterfaceGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_interface_group.test", "name", "my_interface_group"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_interface_group.test", "interface_mode", "ROUTED"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_interface_group.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_intrusion_policy.go
+++ b/internal/provider/data_source_fmc_intrusion_policy.go
@@ -80,6 +80,10 @@ func (d *IntrusionPolicyDataSource) Schema(ctx context.Context, req datasource.S
 				MarkdownDescription: "Description of the policy.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'intrusionpolicy'.",
+				Computed:            true,
+			},
 			"base_policy_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the base policy.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_intrusion_policy_test.go
+++ b/internal/provider/data_source_fmc_intrusion_policy_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcIntrusionPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_intrusion_policy.test", "name", "my_intrusion_policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_intrusion_policy.test", "description", "My IPS Policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_intrusion_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_intrusion_policy.test", "inspection_mode", "PREVENTION"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/data_source_fmc_network_analysis_policy.go
+++ b/internal/provider/data_source_fmc_network_analysis_policy.go
@@ -80,6 +80,10 @@ func (d *NetworkAnalysisPolicyDataSource) Schema(ctx context.Context, req dataso
 				MarkdownDescription: "Description of the policy.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'NetworkAnalysisPolicy'.",
+				Computed:            true,
+			},
 			"base_policy_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the base policy.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_network_analysis_policy_test.go
+++ b/internal/provider/data_source_fmc_network_analysis_policy_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcNetworkAnalysisPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_network_analysis_policy.test", "name", "my_network_analysis_policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_network_analysis_policy.test", "description", "My network analysis policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_network_analysis_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_network_analysis_policy.test", "inspection_mode", "PREVENTION"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/data_source_fmc_network_group.go
+++ b/internal/provider/data_source_fmc_network_group.go
@@ -80,6 +80,10 @@ func (d *NetworkGroupDataSource) Schema(ctx context.Context, req datasource.Sche
 				MarkdownDescription: "Description of the ojbect.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'NetworkGroup'.",
+				Computed:            true,
+			},
 			"overridable": schema.BoolAttribute{
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_network_group_test.go
+++ b/internal/provider/data_source_fmc_network_group_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcNetworkGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_network_group.test", "name", "my_network_group"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_network_group.test", "description", "My Network Group 1"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_network_group.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_network_group.test", "literals.0.value", "10.1.1.0/24"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/data_source_fmc_port.go
+++ b/internal/provider/data_source_fmc_port.go
@@ -92,6 +92,10 @@ func (d *PortDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'ProtocolPortObject'.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_fmc_port_test.go
+++ b/internal/provider/data_source_fmc_port_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceFmcPort(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_port.test", "name", "my_port"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_port.test", "protocol", "TCP"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_port.test", "description", "Port TCP/443 (HTTPS)"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_port.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_range.go
+++ b/internal/provider/data_source_fmc_range.go
@@ -88,6 +88,10 @@ func (d *RangeDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'Range'.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_fmc_range_test.go
+++ b/internal/provider/data_source_fmc_range_test.go
@@ -33,6 +33,7 @@ func TestAccDataSourceFmcRange(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_range.test", "name", "my_range"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_range.test", "ip_range", "10.0.0.1-10.0.0.9"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_range.test", "description", "My range"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_range.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_standard_acl.go
+++ b/internal/provider/data_source_fmc_standard_acl.go
@@ -80,6 +80,10 @@ func (d *StandardACLDataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "Description of the object.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'StandardAccessList'.",
+				Computed:            true,
+			},
 			"entries": schema.ListNestedAttribute{
 				MarkdownDescription: "Ordered list of ACL's entries.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_standard_acl_test.go
+++ b/internal/provider/data_source_fmc_standard_acl_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcStandardACL(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_standard_acl.test", "name", "my_standard_acl"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_standard_acl.test", "description", "My standard ACL"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_standard_acl.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_standard_acl.test", "entries.0.action", "DENY"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_standard_acl.test", "entries.0.literals.0.value", "10.1.1.0/24"))
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/data_source_fmc_url.go
+++ b/internal/provider/data_source_fmc_url.go
@@ -88,6 +88,10 @@ func (d *URLDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'Url'.",
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_fmc_url_group.go
+++ b/internal/provider/data_source_fmc_url_group.go
@@ -80,6 +80,10 @@ func (d *URLGroupDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				MarkdownDescription: "Description of the object.",
 				Computed:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type of the object; this value is always 'UrlGroup'.",
+				Computed:            true,
+			},
 			"overridable": schema.BoolAttribute{
 				MarkdownDescription: "Indicates whether object values can be overridden.",
 				Computed:            true,

--- a/internal/provider/data_source_fmc_url_group_test.go
+++ b/internal/provider/data_source_fmc_url_group_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcURLGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url_group.test", "name", "my_url_group"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url_group.test", "description", "My URL group"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_url_group.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url_group.test", "literals.0.url", "https://www.example.com/app"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/data_source_fmc_url_groups.go
+++ b/internal/provider/data_source_fmc_url_groups.go
@@ -79,6 +79,10 @@ func (d *URLGroupsDataSource) Schema(ctx context.Context, req datasource.SchemaR
 							MarkdownDescription: "Description of the object.",
 							Computed:            true,
 						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: "Type of the object; this value is always 'UrlGroup'.",
+							Computed:            true,
+						},
 						"overridable": schema.BoolAttribute{
 							MarkdownDescription: "Indicates whether object values can be overridden.",
 							Computed:            true,

--- a/internal/provider/data_source_fmc_url_groups_test.go
+++ b/internal/provider/data_source_fmc_url_groups_test.go
@@ -32,6 +32,7 @@ func TestAccDataSourceFmcURLGroups(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_url_groups.test", "items.url_group_1.id"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url_groups.test", "items.url_group_1.description", "My URL group"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_url_groups.test", "items.url_group_1.type"))
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_url_groups.test", "items.url_group_1.urls.0.id"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url_groups.test", "items.url_group_1.literals.0.url", "https://www.example.com/app"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url_groups.test", "items.url_group_1.literals.0.url", "https://www.example.com/app"))

--- a/internal/provider/data_source_fmc_url_test.go
+++ b/internal/provider/data_source_fmc_url_test.go
@@ -33,6 +33,7 @@ func TestAccDataSourceFmcURL(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url.test", "name", "my_url"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url.test", "url", "https://www.example.com/app"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_url.test", "description", "My URL"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_url.test", "type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/data_source_fmc_urls.go
+++ b/internal/provider/data_source_fmc_urls.go
@@ -87,6 +87,10 @@ func (d *URLsDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 							MarkdownDescription: "Indicates whether object values can be overridden.",
 							Computed:            true,
 						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: "Type of the object; this value is always 'Url'.",
+							Computed:            true,
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_fmc_urls_test.go
+++ b/internal/provider/data_source_fmc_urls_test.go
@@ -33,6 +33,7 @@ func TestAccDataSourceFmcURLs(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_urls.test", "items.url_1.id"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_urls.test", "items.url_1.url", "https://www.example.com/app"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_urls.test", "items.url_1.description", "My URL"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_urls.test", "items.url_1.type"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/model_fmc_access_control_policy.go
+++ b/internal/provider/model_fmc_access_control_policy.go
@@ -42,6 +42,7 @@ type AccessControlPolicy struct {
 	Id                             types.String                    `tfsdk:"id"`
 	Domain                         types.String                    `tfsdk:"domain"`
 	Name                           types.String                    `tfsdk:"name"`
+	Type                           types.String                    `tfsdk:"type"`
 	Description                    types.String                    `tfsdk:"description"`
 	DefaultAction                  types.String                    `tfsdk:"default_action"`
 	DefaultActionId                types.String                    `tfsdk:"default_action_id"`
@@ -579,6 +580,11 @@ func (data *AccessControlPolicy) fromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.Name = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("description"); value.Exists() {
 		data.Description = types.StringValue(value.String())
 	} else {
@@ -1089,6 +1095,11 @@ func (data *AccessControlPolicy) fromBodyPartial(ctx context.Context, res gjson.
 		data.Name = types.StringValue(value.String())
 	} else {
 		data.Name = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	if value := res.Get("description"); value.Exists() && !data.Description.IsNull() {
 		data.Description = types.StringValue(value.String())
@@ -2156,6 +2167,13 @@ func (data *AccessControlPolicy) adjustFromBody(ctx context.Context, res gjson.R
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *AccessControlPolicy) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 	if data.DefaultActionId.IsUnknown() {
 		if value := res.Get("defaultAction.id"); value.Exists() {
 			data.DefaultActionId = types.StringValue(value.String())

--- a/internal/provider/model_fmc_device_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_ipv4_static_route.go
@@ -39,6 +39,7 @@ type DeviceIPv4StaticRoute struct {
 	Domain               types.String                               `tfsdk:"domain"`
 	DeviceId             types.String                               `tfsdk:"device_id"`
 	InterfaceLogicalName types.String                               `tfsdk:"interface_logical_name"`
+	Type                 types.String                               `tfsdk:"type"`
 	InterfaceId          types.String                               `tfsdk:"interface_id"`
 	DestinationNetworks  []DeviceIPv4StaticRouteDestinationNetworks `tfsdk:"destination_networks"`
 	MetricValue          types.Int64                                `tfsdk:"metric_value"`
@@ -109,6 +110,11 @@ func (data *DeviceIPv4StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("selectedNetworks"); value.Exists() {
 		data.DestinationNetworks = make([]DeviceIPv4StaticRouteDestinationNetworks, 0)
 		value.ForEach(func(k, res gjson.Result) bool {
@@ -158,6 +164,11 @@ func (data *DeviceIPv4StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	for i := 0; i < len(data.DestinationNetworks); i++ {
 		keys := [...]string{"id"}
@@ -231,6 +242,13 @@ func (data *DeviceIPv4StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *DeviceIPv4StaticRoute) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_ipv6_static_route.go
@@ -39,11 +39,12 @@ type DeviceIPv6StaticRoute struct {
 	Domain               types.String                               `tfsdk:"domain"`
 	DeviceId             types.String                               `tfsdk:"device_id"`
 	InterfaceLogicalName types.String                               `tfsdk:"interface_logical_name"`
+	Type                 types.String                               `tfsdk:"type"`
 	InterfaceId          types.String                               `tfsdk:"interface_id"`
 	DestinationNetworks  []DeviceIPv6StaticRouteDestinationNetworks `tfsdk:"destination_networks"`
 	MetricValue          types.Int64                                `tfsdk:"metric_value"`
-	GatewayObjectId      types.String                               `tfsdk:"gateway_object_id"`
-	GatewayLiteral       types.String                               `tfsdk:"gateway_literal"`
+	GatewayHostObjectId  types.String                               `tfsdk:"gateway_host_object_id"`
+	GatewayHostLiteral   types.String                               `tfsdk:"gateway_host_literal"`
 	IsTunneled           types.Bool                                 `tfsdk:"is_tunneled"`
 }
 
@@ -87,11 +88,11 @@ func (data DeviceIPv6StaticRoute) toBody(ctx context.Context, state DeviceIPv6St
 	if !data.MetricValue.IsNull() {
 		body, _ = sjson.Set(body, "metricValue", data.MetricValue.ValueInt64())
 	}
-	if !data.GatewayObjectId.IsNull() {
-		body, _ = sjson.Set(body, "gateway.object.id", data.GatewayObjectId.ValueString())
+	if !data.GatewayHostObjectId.IsNull() {
+		body, _ = sjson.Set(body, "gateway.object.id", data.GatewayHostObjectId.ValueString())
 	}
-	if !data.GatewayLiteral.IsNull() {
-		body, _ = sjson.Set(body, "gateway.literal.value", data.GatewayLiteral.ValueString())
+	if !data.GatewayHostLiteral.IsNull() {
+		body, _ = sjson.Set(body, "gateway.literal.value", data.GatewayHostLiteral.ValueString())
 	}
 	if !data.IsTunneled.IsNull() {
 		body, _ = sjson.Set(body, "isTunneled", data.IsTunneled.ValueBool())
@@ -108,6 +109,11 @@ func (data *DeviceIPv6StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	if value := res.Get("selectedNetworks"); value.Exists() {
 		data.DestinationNetworks = make([]DeviceIPv6StaticRouteDestinationNetworks, 0)
@@ -129,14 +135,14 @@ func (data *DeviceIPv6StaticRoute) fromBody(ctx context.Context, res gjson.Resul
 		data.MetricValue = types.Int64Null()
 	}
 	if value := res.Get("gateway.object.id"); value.Exists() {
-		data.GatewayObjectId = types.StringValue(value.String())
+		data.GatewayHostObjectId = types.StringValue(value.String())
 	} else {
-		data.GatewayObjectId = types.StringNull()
+		data.GatewayHostObjectId = types.StringNull()
 	}
 	if value := res.Get("gateway.literal.value"); value.Exists() {
-		data.GatewayLiteral = types.StringValue(value.String())
+		data.GatewayHostLiteral = types.StringValue(value.String())
 	} else {
-		data.GatewayLiteral = types.StringNull()
+		data.GatewayHostLiteral = types.StringNull()
 	}
 	if value := res.Get("isTunneled"); value.Exists() {
 		data.IsTunneled = types.BoolValue(value.Bool())
@@ -158,6 +164,11 @@ func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	for i := 0; i < len(data.DestinationNetworks); i++ {
 		keys := [...]string{"id"}
@@ -207,15 +218,15 @@ func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 	} else {
 		data.MetricValue = types.Int64Null()
 	}
-	if value := res.Get("gateway.object.id"); value.Exists() && !data.GatewayObjectId.IsNull() {
-		data.GatewayObjectId = types.StringValue(value.String())
+	if value := res.Get("gateway.object.id"); value.Exists() && !data.GatewayHostObjectId.IsNull() {
+		data.GatewayHostObjectId = types.StringValue(value.String())
 	} else {
-		data.GatewayObjectId = types.StringNull()
+		data.GatewayHostObjectId = types.StringNull()
 	}
-	if value := res.Get("gateway.literal.value"); value.Exists() && !data.GatewayLiteral.IsNull() {
-		data.GatewayLiteral = types.StringValue(value.String())
+	if value := res.Get("gateway.literal.value"); value.Exists() && !data.GatewayHostLiteral.IsNull() {
+		data.GatewayHostLiteral = types.StringValue(value.String())
 	} else {
-		data.GatewayLiteral = types.StringNull()
+		data.GatewayHostLiteral = types.StringNull()
 	}
 	if value := res.Get("isTunneled"); value.Exists() && !data.IsTunneled.IsNull() {
 		data.IsTunneled = types.BoolValue(value.Bool())
@@ -231,6 +242,13 @@ func (data *DeviceIPv6StaticRoute) fromBodyPartial(ctx context.Context, res gjso
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *DeviceIPv6StaticRoute) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_vrf_ipv4_static_route.go
+++ b/internal/provider/model_fmc_device_vrf_ipv4_static_route.go
@@ -40,6 +40,7 @@ type DeviceVRFIPv4StaticRoute struct {
 	DeviceId             types.String                                  `tfsdk:"device_id"`
 	VrfId                types.String                                  `tfsdk:"vrf_id"`
 	InterfaceLogicalName types.String                                  `tfsdk:"interface_logical_name"`
+	Type                 types.String                                  `tfsdk:"type"`
 	InterfaceId          types.String                                  `tfsdk:"interface_id"`
 	DestinationNetworks  []DeviceVRFIPv4StaticRouteDestinationNetworks `tfsdk:"destination_networks"`
 	MetricValue          types.Int64                                   `tfsdk:"metric_value"`
@@ -110,6 +111,11 @@ func (data *DeviceVRFIPv4StaticRoute) fromBody(ctx context.Context, res gjson.Re
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("selectedNetworks"); value.Exists() {
 		data.DestinationNetworks = make([]DeviceVRFIPv4StaticRouteDestinationNetworks, 0)
 		value.ForEach(func(k, res gjson.Result) bool {
@@ -159,6 +165,11 @@ func (data *DeviceVRFIPv4StaticRoute) fromBodyPartial(ctx context.Context, res g
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	for i := 0; i < len(data.DestinationNetworks); i++ {
 		keys := [...]string{"id"}
@@ -232,6 +243,13 @@ func (data *DeviceVRFIPv4StaticRoute) fromBodyPartial(ctx context.Context, res g
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *DeviceVRFIPv4StaticRoute) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_device_vrf_ipv6_static_route.go
+++ b/internal/provider/model_fmc_device_vrf_ipv6_static_route.go
@@ -40,11 +40,12 @@ type DeviceVRFIPv6StaticRoute struct {
 	DeviceId             types.String                                  `tfsdk:"device_id"`
 	VrfId                types.String                                  `tfsdk:"vrf_id"`
 	InterfaceLogicalName types.String                                  `tfsdk:"interface_logical_name"`
+	Type                 types.String                                  `tfsdk:"type"`
 	InterfaceId          types.String                                  `tfsdk:"interface_id"`
 	DestinationNetworks  []DeviceVRFIPv6StaticRouteDestinationNetworks `tfsdk:"destination_networks"`
 	MetricValue          types.Int64                                   `tfsdk:"metric_value"`
-	GatewayObjectId      types.String                                  `tfsdk:"gateway_object_id"`
-	GatewayLiteral       types.String                                  `tfsdk:"gateway_literal"`
+	GatewayHostObjectId  types.String                                  `tfsdk:"gateway_host_object_id"`
+	GatewayHostLiteral   types.String                                  `tfsdk:"gateway_host_literal"`
 	IsTunneled           types.Bool                                    `tfsdk:"is_tunneled"`
 }
 
@@ -88,11 +89,11 @@ func (data DeviceVRFIPv6StaticRoute) toBody(ctx context.Context, state DeviceVRF
 	if !data.MetricValue.IsNull() {
 		body, _ = sjson.Set(body, "metricValue", data.MetricValue.ValueInt64())
 	}
-	if !data.GatewayObjectId.IsNull() {
-		body, _ = sjson.Set(body, "gateway.object.id", data.GatewayObjectId.ValueString())
+	if !data.GatewayHostObjectId.IsNull() {
+		body, _ = sjson.Set(body, "gateway.object.id", data.GatewayHostObjectId.ValueString())
 	}
-	if !data.GatewayLiteral.IsNull() {
-		body, _ = sjson.Set(body, "gateway.literal.value", data.GatewayLiteral.ValueString())
+	if !data.GatewayHostLiteral.IsNull() {
+		body, _ = sjson.Set(body, "gateway.literal.value", data.GatewayHostLiteral.ValueString())
 	}
 	if !data.IsTunneled.IsNull() {
 		body, _ = sjson.Set(body, "isTunneled", data.IsTunneled.ValueBool())
@@ -109,6 +110,11 @@ func (data *DeviceVRFIPv6StaticRoute) fromBody(ctx context.Context, res gjson.Re
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	if value := res.Get("selectedNetworks"); value.Exists() {
 		data.DestinationNetworks = make([]DeviceVRFIPv6StaticRouteDestinationNetworks, 0)
@@ -130,14 +136,14 @@ func (data *DeviceVRFIPv6StaticRoute) fromBody(ctx context.Context, res gjson.Re
 		data.MetricValue = types.Int64Null()
 	}
 	if value := res.Get("gateway.object.id"); value.Exists() {
-		data.GatewayObjectId = types.StringValue(value.String())
+		data.GatewayHostObjectId = types.StringValue(value.String())
 	} else {
-		data.GatewayObjectId = types.StringNull()
+		data.GatewayHostObjectId = types.StringNull()
 	}
 	if value := res.Get("gateway.literal.value"); value.Exists() {
-		data.GatewayLiteral = types.StringValue(value.String())
+		data.GatewayHostLiteral = types.StringValue(value.String())
 	} else {
-		data.GatewayLiteral = types.StringNull()
+		data.GatewayHostLiteral = types.StringNull()
 	}
 	if value := res.Get("isTunneled"); value.Exists() {
 		data.IsTunneled = types.BoolValue(value.Bool())
@@ -159,6 +165,11 @@ func (data *DeviceVRFIPv6StaticRoute) fromBodyPartial(ctx context.Context, res g
 		data.InterfaceLogicalName = types.StringValue(value.String())
 	} else {
 		data.InterfaceLogicalName = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	for i := 0; i < len(data.DestinationNetworks); i++ {
 		keys := [...]string{"id"}
@@ -208,15 +219,15 @@ func (data *DeviceVRFIPv6StaticRoute) fromBodyPartial(ctx context.Context, res g
 	} else {
 		data.MetricValue = types.Int64Null()
 	}
-	if value := res.Get("gateway.object.id"); value.Exists() && !data.GatewayObjectId.IsNull() {
-		data.GatewayObjectId = types.StringValue(value.String())
+	if value := res.Get("gateway.object.id"); value.Exists() && !data.GatewayHostObjectId.IsNull() {
+		data.GatewayHostObjectId = types.StringValue(value.String())
 	} else {
-		data.GatewayObjectId = types.StringNull()
+		data.GatewayHostObjectId = types.StringNull()
 	}
-	if value := res.Get("gateway.literal.value"); value.Exists() && !data.GatewayLiteral.IsNull() {
-		data.GatewayLiteral = types.StringValue(value.String())
+	if value := res.Get("gateway.literal.value"); value.Exists() && !data.GatewayHostLiteral.IsNull() {
+		data.GatewayHostLiteral = types.StringValue(value.String())
 	} else {
-		data.GatewayLiteral = types.StringNull()
+		data.GatewayHostLiteral = types.StringNull()
 	}
 	if value := res.Get("isTunneled"); value.Exists() && !data.IsTunneled.IsNull() {
 		data.IsTunneled = types.BoolValue(value.Bool())
@@ -232,6 +243,13 @@ func (data *DeviceVRFIPv6StaticRoute) fromBodyPartial(ctx context.Context, res g
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *DeviceVRFIPv6StaticRoute) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_extended_acl.go
+++ b/internal/provider/model_fmc_extended_acl.go
@@ -38,6 +38,7 @@ type ExtendedACL struct {
 	Domain      types.String         `tfsdk:"domain"`
 	Name        types.String         `tfsdk:"name"`
 	Description types.String         `tfsdk:"description"`
+	Type        types.String         `tfsdk:"type"`
 	Entries     []ExtendedACLEntries `tfsdk:"entries"`
 }
 
@@ -276,6 +277,11 @@ func (data *ExtendedACL) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("entries"); value.Exists() {
 		data.Entries = make([]ExtendedACLEntries, 0)
 		value.ForEach(func(k, res gjson.Result) bool {
@@ -501,6 +507,11 @@ func (data *ExtendedACL) fromBodyPartial(ctx context.Context, res gjson.Result) 
 		data.Description = types.StringValue(value.String())
 	} else {
 		data.Description = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	{
 		l := len(res.Get("entries").Array())
@@ -985,6 +996,13 @@ func (data *ExtendedACL) fromBodyPartial(ctx context.Context, res gjson.Result) 
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *ExtendedACL) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_fqdn_object.go
+++ b/internal/provider/model_fmc_fqdn_object.go
@@ -38,6 +38,7 @@ type FQDNObject struct {
 	DnsResolution types.String `tfsdk:"dns_resolution"`
 	Description   types.String `tfsdk:"description"`
 	Overridable   types.Bool   `tfsdk:"overridable"`
+	Type          types.String `tfsdk:"type"`
 }
 
 // End of section. //template:end types
@@ -105,6 +106,11 @@ func (data *FQDNObject) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBody
@@ -141,6 +147,11 @@ func (data *FQDNObject) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBodyPartial
@@ -150,6 +161,13 @@ func (data *FQDNObject) fromBodyPartial(ctx context.Context, res gjson.Result) {
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *FQDNObject) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_fqdn_objects.go
+++ b/internal/provider/model_fmc_fqdn_objects.go
@@ -84,9 +84,6 @@ func (data FQDNObjects) toBody(ctx context.Context, state FQDNObjects) string {
 			if !item.DnsResolution.IsNull() {
 				itemBody, _ = sjson.Set(itemBody, "dnsResolution", item.DnsResolution.ValueString())
 			}
-			if !item.Type.IsNull() {
-				itemBody, _ = sjson.Set(itemBody, "type", item.Type.ValueString())
-			}
 			body, _ = sjson.SetRaw(body, "items.-1", itemBody)
 		}
 	}
@@ -146,7 +143,7 @@ func (data *FQDNObjects) fromBody(ctx context.Context, res gjson.Result) {
 		if value := res.Get("type"); value.Exists() {
 			data.Type = types.StringValue(value.String())
 		} else {
-			data.Type = types.StringValue("FQDN")
+			data.Type = types.StringNull()
 		}
 		(*parent).Items[k] = data
 	}
@@ -203,7 +200,7 @@ func (data *FQDNObjects) fromBodyPartial(ctx context.Context, res gjson.Result) 
 		}
 		if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
 			data.Type = types.StringValue(value.String())
-		} else if data.Type.ValueString() != "FQDN" {
+		} else {
 			data.Type = types.StringNull()
 		}
 		(*parent).Items[i] = data
@@ -241,6 +238,14 @@ func (data *FQDNObjects) fromBodyUnknowns(ctx context.Context, res gjson.Result)
 				v.Id = types.StringValue(value.String())
 			} else {
 				v.Id = types.StringNull()
+			}
+			data.Items[i] = v
+		}
+		if v := data.Items[i]; v.Type.IsUnknown() {
+			if value := r.Get("type"); value.Exists() {
+				v.Type = types.StringValue(value.String())
+			} else {
+				v.Type = types.StringNull()
 			}
 			data.Items[i] = v
 		}

--- a/internal/provider/model_fmc_ftd_nat_policy.go
+++ b/internal/provider/model_fmc_ftd_nat_policy.go
@@ -38,6 +38,7 @@ type FTDNATPolicy struct {
 	Domain         types.String                 `tfsdk:"domain"`
 	Name           types.String                 `tfsdk:"name"`
 	Description    types.String                 `tfsdk:"description"`
+	Type           types.String                 `tfsdk:"type"`
 	ManualNatRules []FTDNATPolicyManualNatRules `tfsdk:"manual_nat_rules"`
 	AutoNatRules   []FTDNATPolicyAutoNatRules   `tfsdk:"auto_nat_rules"`
 }
@@ -262,6 +263,11 @@ func (data *FTDNATPolicy) fromBody(ctx context.Context, res gjson.Result) {
 		data.Description = types.StringValue(value.String())
 	} else {
 		data.Description = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	if value := res.Get("dummy_manual_nat_rules"); value.Exists() {
 		data.ManualNatRules = make([]FTDNATPolicyManualNatRules, 0)
@@ -501,6 +507,11 @@ func (data *FTDNATPolicy) fromBodyPartial(ctx context.Context, res gjson.Result)
 		data.Description = types.StringValue(value.String())
 	} else {
 		data.Description = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	{
 		l := len(res.Get("dummy_manual_nat_rules").Array())
@@ -766,6 +777,13 @@ func (data *FTDNATPolicy) fromBodyPartial(ctx context.Context, res gjson.Result)
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *FTDNATPolicy) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 	for i := range data.ManualNatRules {
 		r := res.Get(fmt.Sprintf("dummy_manual_nat_rules.%d", i))
 		if v := data.ManualNatRules[i]; v.Id.IsUnknown() {

--- a/internal/provider/model_fmc_icmpv6_object.go
+++ b/internal/provider/model_fmc_icmpv6_object.go
@@ -38,6 +38,7 @@ type ICMPv6Object struct {
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	Overridable types.Bool   `tfsdk:"overridable"`
+	Type        types.String `tfsdk:"type"`
 }
 
 // End of section. //template:end types
@@ -105,6 +106,11 @@ func (data *ICMPv6Object) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBody
@@ -141,6 +147,11 @@ func (data *ICMPv6Object) fromBodyPartial(ctx context.Context, res gjson.Result)
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBodyPartial
@@ -150,6 +161,13 @@ func (data *ICMPv6Object) fromBodyPartial(ctx context.Context, res gjson.Result)
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *ICMPv6Object) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_interface_group.go
+++ b/internal/provider/model_fmc_interface_group.go
@@ -38,6 +38,7 @@ type InterfaceGroup struct {
 	Domain        types.String               `tfsdk:"domain"`
 	Name          types.String               `tfsdk:"name"`
 	InterfaceMode types.String               `tfsdk:"interface_mode"`
+	Type          types.String               `tfsdk:"type"`
 	Interfaces    []InterfaceGroupInterfaces `tfsdk:"interfaces"`
 }
 
@@ -96,6 +97,11 @@ func (data *InterfaceGroup) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.InterfaceMode = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("interfaces"); value.Exists() {
 		data.Interfaces = make([]InterfaceGroupInterfaces, 0)
 		value.ForEach(func(k, res gjson.Result) bool {
@@ -130,6 +136,11 @@ func (data *InterfaceGroup) fromBodyPartial(ctx context.Context, res gjson.Resul
 		data.InterfaceMode = types.StringValue(value.String())
 	} else {
 		data.InterfaceMode = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	for i := 0; i < len(data.Interfaces); i++ {
 		keys := [...]string{"id"}
@@ -183,6 +194,13 @@ func (data *InterfaceGroup) fromBodyPartial(ctx context.Context, res gjson.Resul
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *InterfaceGroup) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_intrusion_policy.go
+++ b/internal/provider/model_fmc_intrusion_policy.go
@@ -35,6 +35,7 @@ type IntrusionPolicy struct {
 	Domain         types.String `tfsdk:"domain"`
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
+	Type           types.String `tfsdk:"type"`
 	BasePolicyId   types.String `tfsdk:"base_policy_id"`
 	InspectionMode types.String `tfsdk:"inspection_mode"`
 }
@@ -86,6 +87,11 @@ func (data *IntrusionPolicy) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("basePolicy.id"); value.Exists() {
 		data.BasePolicyId = types.StringValue(value.String())
 	} else {
@@ -117,6 +123,11 @@ func (data *IntrusionPolicy) fromBodyPartial(ctx context.Context, res gjson.Resu
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("basePolicy.id"); value.Exists() && !data.BasePolicyId.IsNull() {
 		data.BasePolicyId = types.StringValue(value.String())
 	} else {
@@ -136,6 +147,13 @@ func (data *IntrusionPolicy) fromBodyPartial(ctx context.Context, res gjson.Resu
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *IntrusionPolicy) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_network_analysis_policy.go
+++ b/internal/provider/model_fmc_network_analysis_policy.go
@@ -35,6 +35,7 @@ type NetworkAnalysisPolicy struct {
 	Domain         types.String `tfsdk:"domain"`
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
+	Type           types.String `tfsdk:"type"`
 	BasePolicyId   types.String `tfsdk:"base_policy_id"`
 	InspectionMode types.String `tfsdk:"inspection_mode"`
 }
@@ -86,6 +87,11 @@ func (data *NetworkAnalysisPolicy) fromBody(ctx context.Context, res gjson.Resul
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("basePolicy.id"); value.Exists() {
 		data.BasePolicyId = types.StringValue(value.String())
 	} else {
@@ -117,6 +123,11 @@ func (data *NetworkAnalysisPolicy) fromBodyPartial(ctx context.Context, res gjso
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("basePolicy.id"); value.Exists() && !data.BasePolicyId.IsNull() {
 		data.BasePolicyId = types.StringValue(value.String())
 	} else {
@@ -136,6 +147,13 @@ func (data *NetworkAnalysisPolicy) fromBodyPartial(ctx context.Context, res gjso
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *NetworkAnalysisPolicy) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_network_group.go
+++ b/internal/provider/model_fmc_network_group.go
@@ -38,6 +38,7 @@ type NetworkGroup struct {
 	Domain      types.String           `tfsdk:"domain"`
 	Name        types.String           `tfsdk:"name"`
 	Description types.String           `tfsdk:"description"`
+	Type        types.String           `tfsdk:"type"`
 	Overridable types.Bool             `tfsdk:"overridable"`
 	Objects     []NetworkGroupObjects  `tfsdk:"objects"`
 	Literals    []NetworkGroupLiterals `tfsdk:"literals"`
@@ -117,6 +118,11 @@ func (data *NetworkGroup) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("overridable"); value.Exists() {
 		data.Overridable = types.BoolValue(value.Bool())
 	} else {
@@ -170,6 +176,11 @@ func (data *NetworkGroup) fromBodyPartial(ctx context.Context, res gjson.Result)
 		data.Description = types.StringValue(value.String())
 	} else {
 		data.Description = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	if value := res.Get("overridable"); value.Exists() && !data.Overridable.IsNull() {
 		data.Overridable = types.BoolValue(value.Bool())
@@ -271,6 +282,13 @@ func (data *NetworkGroup) fromBodyPartial(ctx context.Context, res gjson.Result)
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *NetworkGroup) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_network_groups.go
+++ b/internal/provider/model_fmc_network_groups.go
@@ -44,6 +44,7 @@ type NetworkGroups struct {
 type NetworkGroupsItems struct {
 	Id            types.String                 `tfsdk:"id"`
 	Description   types.String                 `tfsdk:"description"`
+	Type          types.String                 `tfsdk:"type"`
 	Overridable   types.Bool                   `tfsdk:"overridable"`
 	NetworkGroups types.Set                    `tfsdk:"network_groups"`
 	Objects       []NetworkGroupsItemsObjects  `tfsdk:"objects"`
@@ -155,6 +156,11 @@ func (data *NetworkGroups) fromBody(ctx context.Context, res gjson.Result) {
 		} else {
 			data.Description = types.StringNull()
 		}
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
 		if value := res.Get("overridable"); value.Exists() {
 			data.Overridable = types.BoolValue(value.Bool())
 		} else {
@@ -230,6 +236,11 @@ func (data *NetworkGroups) fromBodyPartial(ctx context.Context, res gjson.Result
 			data.Description = types.StringValue(value.String())
 		} else {
 			data.Description = types.StringNull()
+		}
+		if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
 		}
 		if value := res.Get("overridable"); value.Exists() && !data.Overridable.IsNull() {
 			data.Overridable = types.BoolValue(value.Bool())
@@ -362,6 +373,14 @@ func (data *NetworkGroups) fromBodyUnknowns(ctx context.Context, res gjson.Resul
 				v.Id = types.StringValue(value.String())
 			} else {
 				v.Id = types.StringNull()
+			}
+			data.Items[i] = v
+		}
+		if v := data.Items[i]; v.Type.IsUnknown() {
+			if value := r.Get("type"); value.Exists() {
+				v.Type = types.StringValue(value.String())
+			} else {
+				v.Type = types.StringNull()
 			}
 			data.Items[i] = v
 		}

--- a/internal/provider/model_fmc_port.go
+++ b/internal/provider/model_fmc_port.go
@@ -38,6 +38,7 @@ type Port struct {
 	Protocol    types.String `tfsdk:"protocol"`
 	Description types.String `tfsdk:"description"`
 	Overridable types.Bool   `tfsdk:"overridable"`
+	Type        types.String `tfsdk:"type"`
 }
 
 // End of section. //template:end types
@@ -105,6 +106,11 @@ func (data *Port) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBody
@@ -141,6 +147,11 @@ func (data *Port) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBodyPartial
@@ -150,6 +161,13 @@ func (data *Port) fromBodyPartial(ctx context.Context, res gjson.Result) {
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *Port) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_range.go
+++ b/internal/provider/model_fmc_range.go
@@ -37,6 +37,7 @@ type Range struct {
 	IpRange     types.String `tfsdk:"ip_range"`
 	Description types.String `tfsdk:"description"`
 	Overridable types.Bool   `tfsdk:"overridable"`
+	Type        types.String `tfsdk:"type"`
 }
 
 // End of section. //template:end types
@@ -96,6 +97,11 @@ func (data *Range) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBody
@@ -127,6 +133,11 @@ func (data *Range) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBodyPartial
@@ -136,6 +147,13 @@ func (data *Range) fromBodyPartial(ctx context.Context, res gjson.Result) {
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *Range) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_standard_acl.go
+++ b/internal/provider/model_fmc_standard_acl.go
@@ -38,6 +38,7 @@ type StandardACL struct {
 	Domain      types.String         `tfsdk:"domain"`
 	Name        types.String         `tfsdk:"name"`
 	Description types.String         `tfsdk:"description"`
+	Type        types.String         `tfsdk:"type"`
 	Entries     []StandardACLEntries `tfsdk:"entries"`
 }
 
@@ -130,6 +131,11 @@ func (data *StandardACL) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("entries"); value.Exists() {
 		data.Entries = make([]StandardACLEntries, 0)
 		value.ForEach(func(k, res gjson.Result) bool {
@@ -197,6 +203,11 @@ func (data *StandardACL) fromBodyPartial(ctx context.Context, res gjson.Result) 
 		data.Description = types.StringValue(value.String())
 	} else {
 		data.Description = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	{
 		l := len(res.Get("entries").Array())
@@ -320,6 +331,13 @@ func (data *StandardACL) fromBodyPartial(ctx context.Context, res gjson.Result) 
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *StandardACL) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_url.go
+++ b/internal/provider/model_fmc_url.go
@@ -37,6 +37,7 @@ type URL struct {
 	Url         types.String `tfsdk:"url"`
 	Description types.String `tfsdk:"description"`
 	Overridable types.Bool   `tfsdk:"overridable"`
+	Type        types.String `tfsdk:"type"`
 }
 
 // End of section. //template:end types
@@ -96,6 +97,11 @@ func (data *URL) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBody
@@ -127,6 +133,11 @@ func (data *URL) fromBodyPartial(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Overridable = types.BoolNull()
 	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 }
 
 // End of section. //template:end fromBodyPartial
@@ -136,6 +147,13 @@ func (data *URL) fromBodyPartial(ctx context.Context, res gjson.Result) {
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *URL) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_url_group.go
+++ b/internal/provider/model_fmc_url_group.go
@@ -38,6 +38,7 @@ type URLGroup struct {
 	Domain      types.String       `tfsdk:"domain"`
 	Name        types.String       `tfsdk:"name"`
 	Description types.String       `tfsdk:"description"`
+	Type        types.String       `tfsdk:"type"`
 	Overridable types.Bool         `tfsdk:"overridable"`
 	Urls        []URLGroupUrls     `tfsdk:"urls"`
 	Literals    []URLGroupLiterals `tfsdk:"literals"`
@@ -115,6 +116,11 @@ func (data *URLGroup) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.Description = types.StringNull()
 	}
+	if value := res.Get("type"); value.Exists() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
+	}
 	if value := res.Get("overridable"); value.Exists() {
 		data.Overridable = types.BoolValue(value.Bool())
 	} else {
@@ -168,6 +174,11 @@ func (data *URLGroup) fromBodyPartial(ctx context.Context, res gjson.Result) {
 		data.Description = types.StringValue(value.String())
 	} else {
 		data.Description = types.StringNull()
+	}
+	if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+		data.Type = types.StringValue(value.String())
+	} else {
+		data.Type = types.StringNull()
 	}
 	if value := res.Get("overridable"); value.Exists() && !data.Overridable.IsNull() {
 		data.Overridable = types.BoolValue(value.Bool())
@@ -269,6 +280,13 @@ func (data *URLGroup) fromBodyPartial(ctx context.Context, res gjson.Result) {
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *URLGroup) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
+	if data.Type.IsUnknown() {
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/model_fmc_url_groups.go
+++ b/internal/provider/model_fmc_url_groups.go
@@ -43,6 +43,7 @@ type URLGroups struct {
 type URLGroupsItems struct {
 	Id          types.String             `tfsdk:"id"`
 	Description types.String             `tfsdk:"description"`
+	Type        types.String             `tfsdk:"type"`
 	Overridable types.Bool               `tfsdk:"overridable"`
 	Urls        []URLGroupsItemsUrls     `tfsdk:"urls"`
 	Literals    []URLGroupsItemsLiterals `tfsdk:"literals"`
@@ -146,6 +147,11 @@ func (data *URLGroups) fromBody(ctx context.Context, res gjson.Result) {
 		} else {
 			data.Description = types.StringNull()
 		}
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
 		if value := res.Get("overridable"); value.Exists() {
 			data.Overridable = types.BoolValue(value.Bool())
 		} else {
@@ -216,6 +222,11 @@ func (data *URLGroups) fromBodyPartial(ctx context.Context, res gjson.Result) {
 			data.Description = types.StringValue(value.String())
 		} else {
 			data.Description = types.StringNull()
+		}
+		if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
 		}
 		if value := res.Get("overridable"); value.Exists() && !data.Overridable.IsNull() {
 			data.Overridable = types.BoolValue(value.Bool())
@@ -343,6 +354,14 @@ func (data *URLGroups) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
 				v.Id = types.StringValue(value.String())
 			} else {
 				v.Id = types.StringNull()
+			}
+			data.Items[i] = v
+		}
+		if v := data.Items[i]; v.Type.IsUnknown() {
+			if value := r.Get("type"); value.Exists() {
+				v.Type = types.StringValue(value.String())
+			} else {
+				v.Type = types.StringNull()
 			}
 			data.Items[i] = v
 		}

--- a/internal/provider/model_fmc_urls.go
+++ b/internal/provider/model_fmc_urls.go
@@ -44,6 +44,7 @@ type URLsItems struct {
 	Url         types.String `tfsdk:"url"`
 	Description types.String `tfsdk:"description"`
 	Overridable types.Bool   `tfsdk:"overridable"`
+	Type        types.String `tfsdk:"type"`
 }
 
 // End of section. //template:end types
@@ -130,6 +131,11 @@ func (data *URLs) fromBody(ctx context.Context, res gjson.Result) {
 		} else {
 			data.Overridable = types.BoolNull()
 		}
+		if value := res.Get("type"); value.Exists() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
 		(*parent).Items[k] = data
 	}
 }
@@ -178,6 +184,11 @@ func (data *URLs) fromBodyPartial(ctx context.Context, res gjson.Result) {
 		} else {
 			data.Overridable = types.BoolNull()
 		}
+		if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
+			data.Type = types.StringValue(value.String())
+		} else {
+			data.Type = types.StringNull()
+		}
 		(*parent).Items[i] = data
 	}
 }
@@ -213,6 +224,14 @@ func (data *URLs) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
 				v.Id = types.StringValue(value.String())
 			} else {
 				v.Id = types.StringNull()
+			}
+			data.Items[i] = v
+		}
+		if v := data.Items[i]; v.Type.IsUnknown() {
+			if value := r.Get("type"); value.Exists() {
+				v.Type = types.StringValue(value.String())
+			} else {
+				v.Type = types.StringNull()
 			}
 			data.Items[i] = v
 		}

--- a/internal/provider/resource_fmc_access_control_policy.go
+++ b/internal/provider/resource_fmc_access_control_policy.go
@@ -91,6 +91,13 @@ func (r *AccessControlPolicyResource) Schema(ctx context.Context, req resource.S
 				MarkdownDescription: helpers.NewAttributeDescription("Name of the Access Control Policy.").String,
 				Required:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'AccessPolicy'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the Access Control Policy.").String,
 				Optional:            true,

--- a/internal/provider/resource_fmc_access_control_policy_test.go
+++ b/internal/provider/resource_fmc_access_control_policy_test.go
@@ -33,6 +33,7 @@ import (
 func TestAccFmcAccessControlPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_access_control_policy.test", "name", "my_access_control_policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_access_control_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_access_control_policy.test", "description", "My Access Control Policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_access_control_policy.test", "default_action", "BLOCK"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_access_control_policy.test", "default_action_log_begin", "true"))

--- a/internal/provider/resource_fmc_device_ipv4_static_route.go
+++ b/internal/provider/resource_fmc_device_ipv4_static_route.go
@@ -92,6 +92,13 @@ func (r *DeviceIPv4StaticRouteResource) Schema(ctx context.Context, req resource
 				MarkdownDescription: helpers.NewAttributeDescription("Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.").String,
 				Required:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'IPv4StaticRoute'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).").String,
 				Required:            true,

--- a/internal/provider/resource_fmc_device_ipv4_static_route_test.go
+++ b/internal/provider/resource_fmc_device_ipv4_static_route_test.go
@@ -34,6 +34,7 @@ func TestAccFmcDeviceIPv4StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_device_ipv4_static_route.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_ipv4_static_route.test", "gateway_host_literal", "10.0.0.1"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_device_ipv6_static_route.go
+++ b/internal/provider/resource_fmc_device_ipv6_static_route.go
@@ -92,6 +92,13 @@ func (r *DeviceIPv6StaticRouteResource) Schema(ctx context.Context, req resource
 				MarkdownDescription: helpers.NewAttributeDescription("Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.").String,
 				Required:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'IPv6StaticRoute'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).").String,
 				Required:            true,
@@ -115,12 +122,12 @@ func (r *DeviceIPv6StaticRouteResource) Schema(ctx context.Context, req resource
 					int64validator.Between(1, 254),
 				},
 			},
-			"gateway_object_id": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Id of the next hop for this route. Exactly one of `gateway_object_id` or `gateway_literal` must be present.").String,
+			"gateway_host_object_id": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Id of the next hop for this route. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.").String,
 				Optional:            true,
 			},
-			"gateway_literal": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("The next hop for this route as a literal IPv6 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.").String,
+			"gateway_host_literal": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("The next hop for this route as a literal IPv6 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.").String,
 				Optional:            true,
 			},
 			"is_tunneled": schema.BoolAttribute{
@@ -328,8 +335,8 @@ func (r *DeviceIPv6StaticRouteResource) ImportState(ctx context.Context, req res
 func (r DeviceIPv6StaticRouteResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcevalidator.Conflicting(
-			path.MatchRoot("gateway_object_id"),
-			path.MatchRoot("gateway_literal"),
+			path.MatchRoot("gateway_host_object_id"),
+			path.MatchRoot("gateway_host_literal"),
 		),
 	}
 }

--- a/internal/provider/resource_fmc_device_ipv6_static_route_test.go
+++ b/internal/provider/resource_fmc_device_ipv6_static_route_test.go
@@ -34,7 +34,8 @@ func TestAccFmcDeviceIPv6StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_ipv6_static_route.test", "gateway_literal", "2024::1"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_device_ipv6_static_route.test", "type"))
+	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_ipv6_static_route.test", "gateway_host_literal", "2024::1"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {
@@ -88,7 +89,7 @@ func testAccFmcDeviceIPv6StaticRouteConfig_minimum() string {
 	config += `		id = data.fmc_host.test.id` + "\n"
 	config += `	}]` + "\n"
 	config += `	metric_value = 254` + "\n"
-	config += `	gateway_literal = "2024::2"` + "\n"
+	config += `	gateway_host_literal = "2024::2"` + "\n"
 	config += `}` + "\n"
 	return config
 }
@@ -106,7 +107,7 @@ func testAccFmcDeviceIPv6StaticRouteConfig_all() string {
 	config += `		id = data.fmc_host.test.id` + "\n"
 	config += `	}]` + "\n"
 	config += `	metric_value = null` + "\n"
-	config += `	gateway_literal = "2024::1"` + "\n"
+	config += `	gateway_host_literal = "2024::1"` + "\n"
 	config += `	is_tunneled = true` + "\n"
 	config += `}` + "\n"
 	return config

--- a/internal/provider/resource_fmc_device_vrf_ipv4_static_route.go
+++ b/internal/provider/resource_fmc_device_vrf_ipv4_static_route.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -98,6 +99,13 @@ func (r *DeviceVRFIPv4StaticRouteResource) Schema(ctx context.Context, req resou
 				MarkdownDescription: helpers.NewAttributeDescription("Logical name of the parent interface. For transparent mode, any bridge group member interface. For routed mode with bridge groups, any bridge group member interface for the BVI name.").String,
 				Required:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'IPv4StaticRoute'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"interface_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the interface provided in `interface_logical_name`. The value is ignored, but the attribute itself is useful for ensuring that Terraform creates interface resource before the static route resource (and destroys the interface resource only after the static route has been destroyed).").String,
 				Required:            true,
@@ -126,7 +134,7 @@ func (r *DeviceVRFIPv4StaticRouteResource) Schema(ctx context.Context, req resou
 				Optional:            true,
 			},
 			"gateway_host_literal": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Next hop for this route as a literal IPv4 address. Exactly one of `gateway_object_id` or `gateway_literal` must be present.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Next hop for this route as a literal IPv4 address. Exactly one of `gateway_host_object_id` or `gateway_host_literal` must be present.").String,
 				Optional:            true,
 			},
 			"is_tunneled": schema.BoolAttribute{
@@ -343,3 +351,12 @@ func (r *DeviceVRFIPv4StaticRouteResource) ImportState(ctx context.Context, req 
 // Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
 
 // End of section. //template:end updateSubresources
+
+func (r DeviceVRFIPv4StaticRouteResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.Conflicting(
+			path.MatchRoot("gateway_host_object_id"),
+			path.MatchRoot("gateway_host_literal"),
+		),
+	}
+}

--- a/internal/provider/resource_fmc_device_vrf_ipv4_static_route_test.go
+++ b/internal/provider/resource_fmc_device_vrf_ipv4_static_route_test.go
@@ -34,6 +34,7 @@ func TestAccFmcDeviceVRFIPv4StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_device_vrf_ipv4_static_route.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_device_vrf_ipv6_static_route_test.go
+++ b/internal/provider/resource_fmc_device_vrf_ipv6_static_route_test.go
@@ -34,6 +34,7 @@ func TestAccFmcDeviceVRFIPv6StaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_device_id")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_device_vrf_ipv6_static_route.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_extended_acl.go
+++ b/internal/provider/resource_fmc_extended_acl.go
@@ -92,6 +92,13 @@ func (r *ExtendedACLResource) Schema(ctx context.Context, req resource.SchemaReq
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the Extended ACL.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'ExtendedAccessList'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"entries": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Ordered list of ACL's entries.").String,
 				Required:            true,

--- a/internal/provider/resource_fmc_extended_acl_test.go
+++ b/internal/provider/resource_fmc_extended_acl_test.go
@@ -33,6 +33,7 @@ func TestAccFmcExtendedACL(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_extended_acl.test", "name", "my_extended_acl"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_extended_acl.test", "description", "My Extended Access Control List"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_extended_acl.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_extended_acl.test", "entries.0.action", "DENY"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_extended_acl.test", "entries.0.log_level", "WARNING"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_extended_acl.test", "entries.0.logging", "PER_ACCESS_LIST_ENTRY"))

--- a/internal/provider/resource_fmc_fqdn_object.go
+++ b/internal/provider/resource_fmc_fqdn_object.go
@@ -105,6 +105,13 @@ func (r *FQDNObjectResource) Schema(ctx context.Context, req resource.SchemaRequ
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'FQDN'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_fmc_fqdn_object_test.go
+++ b/internal/provider/resource_fmc_fqdn_object_test.go
@@ -35,6 +35,7 @@ func TestAccFmcFQDNObject(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_fqdn_object.test", "fqdn", "www.example.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_fqdn_object.test", "dns_resolution", "IPV4_AND_IPV6"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_fqdn_object.test", "description", "My FQDN Object"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_fqdn_object.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_fqdn_objects.go
+++ b/internal/provider/resource_fmc_fqdn_objects.go
@@ -119,10 +119,11 @@ func (r *FQDNObjectsResource) Schema(ctx context.Context, req resource.SchemaReq
 							Default: stringdefault.StaticString("IPV4_AND_IPV6"),
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'FQDN'.").AddDefaultValueDescription("FQDN").String,
-							Optional:            true,
+							MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'FQDN'.").String,
 							Computed:            true,
-							Default:             stringdefault.StaticString("FQDN"),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},

--- a/internal/provider/resource_fmc_fqdn_objects_test.go
+++ b/internal/provider/resource_fmc_fqdn_objects_test.go
@@ -36,6 +36,7 @@ func TestAccFmcFQDNObjects(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_fqdn_objects.test", "items.my_fqdn_objects.overridable", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_fqdn_objects.test", "items.my_fqdn_objects.fqdn", "www.example.com"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_fqdn_objects.test", "items.my_fqdn_objects.dns_resolution", "IPV4_AND_IPV6"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_fqdn_objects.test", "items.my_fqdn_objects.type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_ftd_nat_policy.go
+++ b/internal/provider/resource_fmc_ftd_nat_policy.go
@@ -93,6 +93,13 @@ func (r *FTDNATPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the object.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'FTDNatPolicy'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"manual_nat_rules": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("The ordered list of manual NAT rules.").String,
 				Optional:            true,

--- a/internal/provider/resource_fmc_ftd_nat_policy_test.go
+++ b/internal/provider/resource_fmc_ftd_nat_policy_test.go
@@ -33,6 +33,7 @@ func TestAccFmcFTDNATPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_ftd_nat_policy.test", "name", "my_ftd_nat_policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_ftd_nat_policy.test", "description", "My nat policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_ftd_nat_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_ftd_nat_policy.test", "manual_nat_rules.0.description", "My manual nat rule 1"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_ftd_nat_policy.test", "manual_nat_rules.0.enabled", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_ftd_nat_policy.test", "manual_nat_rules.0.section", "BEFORE_AUTO"))

--- a/internal/provider/resource_fmc_icmpv4_object.go
+++ b/internal/provider/resource_fmc_icmpv4_object.go
@@ -106,7 +106,7 @@ func (r *ICMPv4ObjectResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:            true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'ICMPV4Object'.").String,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/internal/provider/resource_fmc_icmpv4_objects.go
+++ b/internal/provider/resource_fmc_icmpv4_objects.go
@@ -119,7 +119,7 @@ func (r *ICMPv4ObjectsResource) Schema(ctx context.Context, req resource.SchemaR
 							},
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'ICMPV4Object'.").String,
 							Computed:            true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),

--- a/internal/provider/resource_fmc_icmpv6_object.go
+++ b/internal/provider/resource_fmc_icmpv6_object.go
@@ -105,6 +105,13 @@ func (r *ICMPv6ObjectResource) Schema(ctx context.Context, req resource.SchemaRe
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'ICMPV6Object'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_fmc_icmpv6_object_test.go
+++ b/internal/provider/resource_fmc_icmpv6_object_test.go
@@ -35,6 +35,7 @@ func TestAccFmcICMPv6Object(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_icmpv6_object.test", "code", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_icmpv6_object.test", "name", "my_icmpv6_object"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_icmpv6_object.test", "description", "ICMPv6 address unreachable response, type 1, code 3"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_icmpv6_object.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_interface_group.go
+++ b/internal/provider/resource_fmc_interface_group.go
@@ -90,6 +90,13 @@ func (r *InterfaceGroupResource) Schema(ctx context.Context, req resource.Schema
 					stringvalidator.OneOf("INLINE", "SWITCHED", "ROUTED"),
 				},
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'InterfaceGroup'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"interfaces": schema.SetNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("").String,
 				Optional:            true,

--- a/internal/provider/resource_fmc_interface_group_test.go
+++ b/internal/provider/resource_fmc_interface_group_test.go
@@ -36,6 +36,7 @@ func TestAccFmcInterfaceGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_interface_group.test", "name", "my_interface_group"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_interface_group.test", "interface_mode", "ROUTED"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_interface_group.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_intrusion_policy.go
+++ b/internal/provider/resource_fmc_intrusion_policy.go
@@ -87,6 +87,13 @@ func (r *IntrusionPolicyResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the policy.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'intrusionpolicy'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"base_policy_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the base policy.").String,
 				Required:            true,

--- a/internal/provider/resource_fmc_intrusion_policy_test.go
+++ b/internal/provider/resource_fmc_intrusion_policy_test.go
@@ -33,6 +33,7 @@ func TestAccFmcIntrusionPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_intrusion_policy.test", "name", "my_intrusion_policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_intrusion_policy.test", "description", "My IPS Policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_intrusion_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_intrusion_policy.test", "inspection_mode", "PREVENTION"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_network_analysis_policy.go
+++ b/internal/provider/resource_fmc_network_analysis_policy.go
@@ -87,6 +87,13 @@ func (r *NetworkAnalysisPolicyResource) Schema(ctx context.Context, req resource
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the policy.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'NetworkAnalysisPolicy'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"base_policy_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the base policy.").String,
 				Required:            true,

--- a/internal/provider/resource_fmc_network_analysis_policy_test.go
+++ b/internal/provider/resource_fmc_network_analysis_policy_test.go
@@ -33,6 +33,7 @@ func TestAccFmcNetworkAnalysisPolicy(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_analysis_policy.test", "name", "my_network_analysis_policy"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_analysis_policy.test", "description", "My network analysis policy"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_network_analysis_policy.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_analysis_policy.test", "inspection_mode", "PREVENTION"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_network_group.go
+++ b/internal/provider/resource_fmc_network_group.go
@@ -85,6 +85,13 @@ func (r *NetworkGroupResource) Schema(ctx context.Context, req resource.SchemaRe
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the ojbect.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'NetworkGroup'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"overridable": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,

--- a/internal/provider/resource_fmc_network_group_test.go
+++ b/internal/provider/resource_fmc_network_group_test.go
@@ -33,6 +33,7 @@ func TestAccFmcNetworkGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_group.test", "name", "my_network_group"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_group.test", "description", "My Network Group 1"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_network_group.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_group.test", "literals.0.value", "10.1.1.0/24"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_network_groups.go
+++ b/internal/provider/resource_fmc_network_groups.go
@@ -97,6 +97,13 @@ func (r *NetworkGroupsResource) Schema(ctx context.Context, req resource.SchemaR
 							MarkdownDescription: helpers.NewAttributeDescription("Description of the object.").String,
 							Optional:            true,
 						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'NetworkGroup'.").String,
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
 						"overridable": schema.BoolAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 							Optional:            true,

--- a/internal/provider/resource_fmc_network_groups_test.go
+++ b/internal/provider/resource_fmc_network_groups_test.go
@@ -34,6 +34,7 @@ func TestAccFmcNetworkGroups(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_network_groups.test", "items.my_network_groups.id"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_groups.test", "items.my_network_groups.description", "My Network Group 1"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_network_groups.test", "items.my_network_groups.type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_network_groups.test", "items.my_network_groups.literals.0.value", "10.1.1.0/24"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_port.go
+++ b/internal/provider/resource_fmc_port.go
@@ -97,6 +97,13 @@ func (r *PortResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'ProtocolPortObject'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_fmc_port_test.go
+++ b/internal/provider/resource_fmc_port_test.go
@@ -35,6 +35,7 @@ func TestAccFmcPort(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_port.test", "name", "my_port"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_port.test", "protocol", "TCP"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_port.test", "description", "Port TCP/443 (HTTPS)"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_port.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_range.go
+++ b/internal/provider/resource_fmc_range.go
@@ -93,6 +93,13 @@ func (r *RangeResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'Range'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_fmc_range_test.go
+++ b/internal/provider/resource_fmc_range_test.go
@@ -34,6 +34,7 @@ func TestAccFmcRange(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_range.test", "name", "my_range"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_range.test", "ip_range", "10.0.0.1-10.0.0.9"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_range.test", "description", "My range"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_range.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_standard_acl.go
+++ b/internal/provider/resource_fmc_standard_acl.go
@@ -90,6 +90,13 @@ func (r *StandardACLResource) Schema(ctx context.Context, req resource.SchemaReq
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the object.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'StandardAccessList'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"entries": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Ordered list of ACL's entries.").String,
 				Required:            true,

--- a/internal/provider/resource_fmc_standard_acl_test.go
+++ b/internal/provider/resource_fmc_standard_acl_test.go
@@ -33,6 +33,7 @@ func TestAccFmcStandardACL(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_standard_acl.test", "name", "my_standard_acl"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_standard_acl.test", "description", "My standard ACL"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_standard_acl.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_standard_acl.test", "entries.0.action", "DENY"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_standard_acl.test", "entries.0.literals.0.value", "10.1.1.0/24"))
 

--- a/internal/provider/resource_fmc_url.go
+++ b/internal/provider/resource_fmc_url.go
@@ -93,6 +93,13 @@ func (r *URLResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'Url'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/resource_fmc_url_group.go
+++ b/internal/provider/resource_fmc_url_group.go
@@ -85,6 +85,13 @@ func (r *URLGroupResource) Schema(ctx context.Context, req resource.SchemaReques
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the object.").String,
 				Optional:            true,
 			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'UrlGroup'.").String,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"overridable": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 				Optional:            true,

--- a/internal/provider/resource_fmc_url_group_test.go
+++ b/internal/provider/resource_fmc_url_group_test.go
@@ -33,6 +33,7 @@ func TestAccFmcURLGroup(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url_group.test", "name", "my_url_group"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url_group.test", "description", "My URL group"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_url_group.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url_group.test", "literals.0.url", "https://www.example.com/app"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_url_groups.go
+++ b/internal/provider/resource_fmc_url_groups.go
@@ -98,6 +98,13 @@ func (r *URLGroupsResource) Schema(ctx context.Context, req resource.SchemaReque
 							MarkdownDescription: helpers.NewAttributeDescription("Description of the object.").String,
 							Optional:            true,
 						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'UrlGroup'.").String,
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
 						"overridable": schema.BoolAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 							Optional:            true,

--- a/internal/provider/resource_fmc_url_groups_test.go
+++ b/internal/provider/resource_fmc_url_groups_test.go
@@ -33,6 +33,7 @@ func TestAccFmcURLGroups(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_url_groups.test", "items.url_group_1.id"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url_groups.test", "items.url_group_1.description", "My URL group"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_url_groups.test", "items.url_group_1.type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url_groups.test", "items.url_group_1.literals.0.url", "https://www.example.com/app"))
 
 	var steps []resource.TestStep

--- a/internal/provider/resource_fmc_url_test.go
+++ b/internal/provider/resource_fmc_url_test.go
@@ -34,6 +34,7 @@ func TestAccFmcURL(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url.test", "name", "my_url"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url.test", "url", "https://www.example.com/app"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_url.test", "description", "My URL"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_url.test", "type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/internal/provider/resource_fmc_urls.go
+++ b/internal/provider/resource_fmc_urls.go
@@ -106,6 +106,13 @@ func (r *URLsResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 							MarkdownDescription: helpers.NewAttributeDescription("Indicates whether object values can be overridden.").String,
 							Optional:            true,
 						},
+						"type": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Type of the object; this value is always 'Url'.").String,
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_fmc_urls_test.go
+++ b/internal/provider/resource_fmc_urls_test.go
@@ -34,6 +34,7 @@ func TestAccFmcURLs(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_urls.test", "items.url_1.id"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_urls.test", "items.url_1.url", "https://www.example.com/app"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_urls.test", "items.url_1.description", "My URL"))
+	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_urls.test", "items.url_1.type"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,11 @@ description: |-
 
 # Changelog
 
+## 2.0.0-beta2
+
+- (Enhancement) Add `type` field to multiple resources
+- (Fix) Align fields in ipv4/ipv6/vrf_ipv4/vrf_ipv6 static_route resources
+
 ## 2.0.0-beta1
 
 - Initial release

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,10 +7,10 @@ description: |-
 
 # Changelog
 
-## 2.0.0-beta2
+## 2.0.0-beta2 (Unreleased)
 
-- (Enhancement) Add `type` field to multiple resources
 - (Fix) Align fields in ipv4/ipv6/vrf_ipv4/vrf_ipv6 static_route resources
+- (Enhancement) Add `type` field to multiple resources
 
 ## 2.0.0-beta1
 


### PR DESCRIPTION
Added `type` attributes to multiple resources
Align attribute names in ipv4/ipv6/vrf_ipv4/vrf_ipv6 static_route resources 