### PR TITLE
Fix template for `write only` fields

### DIFF
--- a/gen/templates/data_source_test.go
+++ b/gen/templates/data_source_test.go
@@ -59,7 +59,7 @@ func TestAccDataSourceFmc{{camelCase .Name}}(t *testing.T) {
 	{{- if and (not .WriteOnly) (not .ExcludeTest) (not .Value) (not .TestValue) (not .Computed) ( isSet . ) }}
 	{{- $clist := .TfName }}
 	{{- range  .Attributes}}
-	{{- if eq .TfName "id" }}
+	{{- if and (eq .TfName "id") (not .WriteOnly) }}
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_{{snakeCase $name}}.test", "{{$list}}.{{$map}}.{{$clist}}.0.{{.TfName}}"))
 	{{- end}}
 	{{- if and (not .WriteOnly) (not .ExcludeTest) (not .Value) (not .TestValue) (not .Computed) (not (isSet .)) }}

--- a/internal/provider/data_source_fmc_application_filters_test.go
+++ b/internal/provider/data_source_fmc_application_filters_test.go
@@ -32,7 +32,6 @@ func TestAccDataSourceFmcApplicationFilters(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_application_filters.test", "items.my_application_filter.id"))
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_application_filters.test", "items.my_application_filter.type"))
-	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_application_filters.test", "items.my_application_filter.applications.0.id"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
Writeonly template flag was not respected at certain depth in the test template, which resulted in wrong test being generated.