### PR TITLE
Add missing examples

### DIFF
--- a/docs/resources/intrusion_policy.md
+++ b/docs/resources/intrusion_policy.md
@@ -16,7 +16,7 @@ This resource manages an Intrusion Policy.
 resource "fmc_intrusion_policy" "example" {
   name            = "my_intrusion_policy"
   description     = "My IPS Policy"
-  base_policy_id  = ""
+  base_policy_id  = "0050568A-4E02-1ed3-0000-004294969198"
   inspection_mode = "PREVENTION"
 }
 ```

--- a/docs/resources/network_analysis_policy.md
+++ b/docs/resources/network_analysis_policy.md
@@ -16,7 +16,7 @@ This resource manages a Network Analysis Policy.
 resource "fmc_network_analysis_policy" "example" {
   name            = "my_network_analysis_policy"
   description     = "My network analysis policy"
-  base_policy_id  = ""
+  base_policy_id  = "0050568A-4E02-1ed3-0000-004294969198"
   inspection_mode = "PREVENTION"
 }
 ```

--- a/examples/resources/fmc_intrusion_policy/resource.tf
+++ b/examples/resources/fmc_intrusion_policy/resource.tf
@@ -1,6 +1,6 @@
 resource "fmc_intrusion_policy" "example" {
   name            = "my_intrusion_policy"
   description     = "My IPS Policy"
-  base_policy_id  = ""
+  base_policy_id  = "0050568A-4E02-1ed3-0000-004294969198"
   inspection_mode = "PREVENTION"
 }

--- a/examples/resources/fmc_network_analysis_policy/resource.tf
+++ b/examples/resources/fmc_network_analysis_policy/resource.tf
@@ -1,6 +1,6 @@
 resource "fmc_network_analysis_policy" "example" {
   name            = "my_network_analysis_policy"
   description     = "My network analysis policy"
-  base_policy_id  = ""
+  base_policy_id  = "0050568A-4E02-1ed3-0000-004294969198"
   inspection_mode = "PREVENTION"
 }

--- a/gen/definitions/intrusion_policy.yaml
+++ b/gen/definitions/intrusion_policy.yaml
@@ -23,6 +23,7 @@ attributes:
     type: String
     description: Id of the base policy.
     mandatory: true
+    example: 0050568A-4E02-1ed3-0000-004294969198
     test_value: data.fmc_intrusion_policy.builtin.id
   - model_name: inspectionMode
     type: String

--- a/gen/definitions/network_analysis_policy.yaml
+++ b/gen/definitions/network_analysis_policy.yaml
@@ -23,6 +23,7 @@ attributes:
     type: String
     description: Id of the base policy.
     mandatory: true
+    example: 0050568A-4E02-1ed3-0000-004294969198
     test_value: data.fmc_network_analysis_policy.builtin.id
   - model_name: inspectionMode
     type: String


### PR DESCRIPTION
Intrusion Policy and Network Analysis Policy were missing examples in the description.