### PR TITLE
Refactor: templates/resource.go

### DIFF
--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -582,19 +582,23 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 
 	{{- if .IsBulk}}
 	
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := {{camelCase .Name}}{}
-	state.Items = make(map[string]{{camelCase .Name}}Items, len(plan.Items))
-	state.Id = types.StringValue(uuid.New().String())
-	{{- if isDomainDependent .}}
-	state.Domain = plan.Domain
-	{{- end}}
-
-	// Create object
-	// Creation process is put in a separate function, as that same proces will be needed with `Update`
-	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
-	resp.Diagnostics.Append(diags...)
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+    // Copy fields, as those may contain domain information or other references
+    state := plan
+    // Create random ID to track bulk resource. This does not relate to FMC in any way
+    state.Id = types.StringValue(uuid.New().String())
+	// Erase all Items, those will be filled in after creation
+    state.Items = make(map[string]{{camelCase .Name}}Items, len(plan.Items))
+    // Creation process is put in a separate function, as that same proces will be needed with `Update`
+    plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        // Save state for whatever was already created
+        diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+        resp.Diagnostics.Append(diags...)
+        return
+    }
 	{{- end}}
 
 	{{- if not .IsBulk}}
@@ -1086,7 +1090,7 @@ func (r *{{camelCase .Name}}Resource) createSubresources(ctx context.Context, st
 				body := bulk.toBody(ctx, {{camelCase .Name}}{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -1216,7 +1220,7 @@ func (r *{{camelCase .Name}}Resource) updateSubresources(ctx context.Context, st
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_application_filters.go
+++ b/internal/provider/resource_fmc_application_filters.go
@@ -222,17 +222,23 @@ func (r *ApplicationFiltersResource) Create(ctx context.Context, req resource.Cr
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := ApplicationFilters{}
-	state.Items = make(map[string]ApplicationFiltersItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]ApplicationFiltersItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -563,7 +569,7 @@ func (r *ApplicationFiltersResource) createSubresources(ctx context.Context, sta
 				body := bulk.toBody(ctx, ApplicationFilters{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -681,7 +687,7 @@ func (r *ApplicationFiltersResource) updateSubresources(ctx context.Context, sta
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_dynamic_objects.go
+++ b/internal/provider/resource_fmc_dynamic_objects.go
@@ -153,17 +153,23 @@ func (r *DynamicObjectsResource) Create(ctx context.Context, req resource.Create
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := DynamicObjects{}
-	state.Items = make(map[string]DynamicObjectsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]DynamicObjectsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 

--- a/internal/provider/resource_fmc_fqdn_objects.go
+++ b/internal/provider/resource_fmc_fqdn_objects.go
@@ -160,17 +160,23 @@ func (r *FQDNObjectsResource) Create(ctx context.Context, req resource.CreateReq
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := FQDNObjects{}
-	state.Items = make(map[string]FQDNObjectsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]FQDNObjectsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -467,7 +473,7 @@ func (r *FQDNObjectsResource) createSubresources(ctx context.Context, state, pla
 			body := bulk.toBody(ctx, FQDNObjects{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -584,7 +590,7 @@ func (r *FQDNObjectsResource) updateSubresources(ctx context.Context, state, pla
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_hosts.go
+++ b/internal/provider/resource_fmc_hosts.go
@@ -148,17 +148,23 @@ func (r *HostsResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := Hosts{}
-	state.Items = make(map[string]HostsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]HostsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -455,7 +461,7 @@ func (r *HostsResource) createSubresources(ctx context.Context, state, plan Host
 			body := bulk.toBody(ctx, Hosts{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -571,7 +577,7 @@ func (r *HostsResource) updateSubresources(ctx context.Context, state, plan Host
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_icmpv4_objects.go
+++ b/internal/provider/resource_fmc_icmpv4_objects.go
@@ -160,17 +160,23 @@ func (r *ICMPv4ObjectsResource) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := ICMPv4Objects{}
-	state.Items = make(map[string]ICMPv4ObjectsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]ICMPv4ObjectsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -467,7 +473,7 @@ func (r *ICMPv4ObjectsResource) createSubresources(ctx context.Context, state, p
 			body := bulk.toBody(ctx, ICMPv4Objects{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -584,7 +590,7 @@ func (r *ICMPv4ObjectsResource) updateSubresources(ctx context.Context, state, p
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_icmpv6_objects.go
+++ b/internal/provider/resource_fmc_icmpv6_objects.go
@@ -160,17 +160,23 @@ func (r *ICMPv6ObjectsResource) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := ICMPv6Objects{}
-	state.Items = make(map[string]ICMPv6ObjectsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]ICMPv6ObjectsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -467,7 +473,7 @@ func (r *ICMPv6ObjectsResource) createSubresources(ctx context.Context, state, p
 			body := bulk.toBody(ctx, ICMPv6Objects{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -584,7 +590,7 @@ func (r *ICMPv6ObjectsResource) updateSubresources(ctx context.Context, state, p
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ikev1_ipsec_proposals.go
+++ b/internal/provider/resource_fmc_ikev1_ipsec_proposals.go
@@ -158,17 +158,23 @@ func (r *IKEv1IPsecProposalsResource) Create(ctx context.Context, req resource.C
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := IKEv1IPsecProposals{}
-	state.Items = make(map[string]IKEv1IPsecProposalsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]IKEv1IPsecProposalsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -499,7 +505,7 @@ func (r *IKEv1IPsecProposalsResource) createSubresources(ctx context.Context, st
 				body := bulk.toBody(ctx, IKEv1IPsecProposals{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -617,7 +623,7 @@ func (r *IKEv1IPsecProposalsResource) updateSubresources(ctx context.Context, st
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ikev1_policies.go
+++ b/internal/provider/resource_fmc_ikev1_policies.go
@@ -187,17 +187,23 @@ func (r *IKEv1PoliciesResource) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := IKEv1Policies{}
-	state.Items = make(map[string]IKEv1PoliciesItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]IKEv1PoliciesItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -528,7 +534,7 @@ func (r *IKEv1PoliciesResource) createSubresources(ctx context.Context, state, p
 				body := bulk.toBody(ctx, IKEv1Policies{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -646,7 +652,7 @@ func (r *IKEv1PoliciesResource) updateSubresources(ctx context.Context, state, p
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ikev2_ipsec_proposals.go
+++ b/internal/provider/resource_fmc_ikev2_ipsec_proposals.go
@@ -165,17 +165,23 @@ func (r *IKEv2IPsecProposalsResource) Create(ctx context.Context, req resource.C
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := IKEv2IPsecProposals{}
-	state.Items = make(map[string]IKEv2IPsecProposalsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]IKEv2IPsecProposalsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -506,7 +512,7 @@ func (r *IKEv2IPsecProposalsResource) createSubresources(ctx context.Context, st
 				body := bulk.toBody(ctx, IKEv2IPsecProposals{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -624,7 +630,7 @@ func (r *IKEv2IPsecProposalsResource) updateSubresources(ctx context.Context, st
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ikev2_policies.go
+++ b/internal/provider/resource_fmc_ikev2_policies.go
@@ -200,17 +200,23 @@ func (r *IKEv2PoliciesResource) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := IKEv2Policies{}
-	state.Items = make(map[string]IKEv2PoliciesItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]IKEv2PoliciesItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -541,7 +547,7 @@ func (r *IKEv2PoliciesResource) createSubresources(ctx context.Context, state, p
 				body := bulk.toBody(ctx, IKEv2Policies{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -659,7 +665,7 @@ func (r *IKEv2PoliciesResource) updateSubresources(ctx context.Context, state, p
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ipv4_address_pools.go
+++ b/internal/provider/resource_fmc_ipv4_address_pools.go
@@ -154,17 +154,23 @@ func (r *IPv4AddressPoolsResource) Create(ctx context.Context, req resource.Crea
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := IPv4AddressPools{}
-	state.Items = make(map[string]IPv4AddressPoolsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]IPv4AddressPoolsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 

--- a/internal/provider/resource_fmc_ipv6_address_pools.go
+++ b/internal/provider/resource_fmc_ipv6_address_pools.go
@@ -154,17 +154,23 @@ func (r *IPv6AddressPoolsResource) Create(ctx context.Context, req resource.Crea
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := IPv6AddressPools{}
-	state.Items = make(map[string]IPv6AddressPoolsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]IPv6AddressPoolsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -495,7 +501,7 @@ func (r *IPv6AddressPoolsResource) createSubresources(ctx context.Context, state
 				body := bulk.toBody(ctx, IPv6AddressPools{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -613,7 +619,7 @@ func (r *IPv6AddressPoolsResource) updateSubresources(ctx context.Context, state
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_networks.go
+++ b/internal/provider/resource_fmc_networks.go
@@ -148,17 +148,23 @@ func (r *NetworksResource) Create(ctx context.Context, req resource.CreateReques
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := Networks{}
-	state.Items = make(map[string]NetworksItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]NetworksItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -455,7 +461,7 @@ func (r *NetworksResource) createSubresources(ctx context.Context, state, plan N
 			body := bulk.toBody(ctx, Networks{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -572,7 +578,7 @@ func (r *NetworksResource) updateSubresources(ctx context.Context, state, plan N
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_port_groups.go
+++ b/internal/provider/resource_fmc_port_groups.go
@@ -165,17 +165,23 @@ func (r *PortGroupsResource) Create(ctx context.Context, req resource.CreateRequ
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := PortGroups{}
-	state.Items = make(map[string]PortGroupsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]PortGroupsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -472,7 +478,7 @@ func (r *PortGroupsResource) createSubresources(ctx context.Context, state, plan
 			body := bulk.toBody(ctx, PortGroups{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -589,7 +595,7 @@ func (r *PortGroupsResource) updateSubresources(ctx context.Context, state, plan
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ports.go
+++ b/internal/provider/resource_fmc_ports.go
@@ -152,17 +152,23 @@ func (r *PortsResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := Ports{}
-	state.Items = make(map[string]PortsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]PortsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -459,7 +465,7 @@ func (r *PortsResource) createSubresources(ctx context.Context, state, plan Port
 			body := bulk.toBody(ctx, Ports{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -576,7 +582,7 @@ func (r *PortsResource) updateSubresources(ctx context.Context, state, plan Port
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_ranges.go
+++ b/internal/provider/resource_fmc_ranges.go
@@ -148,17 +148,23 @@ func (r *RangesResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := Ranges{}
-	state.Items = make(map[string]RangesItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]RangesItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -455,7 +461,7 @@ func (r *RangesResource) createSubresources(ctx context.Context, state, plan Ran
 			body := bulk.toBody(ctx, Ranges{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -572,7 +578,7 @@ func (r *RangesResource) updateSubresources(ctx context.Context, state, plan Ran
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_security_zones.go
+++ b/internal/provider/resource_fmc_security_zones.go
@@ -146,17 +146,23 @@ func (r *SecurityZonesResource) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := SecurityZones{}
-	state.Items = make(map[string]SecurityZonesItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]SecurityZonesItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -459,7 +465,7 @@ func (r *SecurityZonesResource) createSubresources(ctx context.Context, state, p
 			body := bulk.toBody(ctx, SecurityZones{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -576,7 +582,7 @@ func (r *SecurityZonesResource) updateSubresources(ctx context.Context, state, p
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_sgts.go
+++ b/internal/provider/resource_fmc_sgts.go
@@ -154,17 +154,23 @@ func (r *SGTsResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := SGTs{}
-	state.Items = make(map[string]SGTsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]SGTsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -495,7 +501,7 @@ func (r *SGTsResource) createSubresources(ctx context.Context, state, plan SGTs,
 				body := bulk.toBody(ctx, SGTs{})
 
 				// Execute request
-				urlPath := bulk.getPath() + "?bulk=true"
+				urlPath := plan.getPath() + "?bulk=true"
 				res, err := r.client.Post(urlPath, body, reqMods...)
 				if err != nil {
 					return state, diag.Diagnostics{
@@ -613,7 +619,7 @@ func (r *SGTsResource) updateSubresources(ctx context.Context, state, plan SGTs,
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_time_ranges.go
+++ b/internal/provider/resource_fmc_time_ranges.go
@@ -206,17 +206,23 @@ func (r *TimeRangesResource) Create(ctx context.Context, req resource.CreateRequ
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := TimeRanges{}
-	state.Items = make(map[string]TimeRangesItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]TimeRangesItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -513,7 +519,7 @@ func (r *TimeRangesResource) createSubresources(ctx context.Context, state, plan
 			body := bulk.toBody(ctx, TimeRanges{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -630,7 +636,7 @@ func (r *TimeRangesResource) updateSubresources(ctx context.Context, state, plan
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_tunnel_zones.go
+++ b/internal/provider/resource_fmc_tunnel_zones.go
@@ -140,17 +140,23 @@ func (r *TunnelZonesResource) Create(ctx context.Context, req resource.CreateReq
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := TunnelZones{}
-	state.Items = make(map[string]TunnelZonesItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]TunnelZonesItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -447,7 +453,7 @@ func (r *TunnelZonesResource) createSubresources(ctx context.Context, state, pla
 			body := bulk.toBody(ctx, TunnelZones{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -564,7 +570,7 @@ func (r *TunnelZonesResource) updateSubresources(ctx context.Context, state, pla
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_url_groups.go
+++ b/internal/provider/resource_fmc_url_groups.go
@@ -168,17 +168,23 @@ func (r *URLGroupsResource) Create(ctx context.Context, req resource.CreateReque
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := URLGroups{}
-	state.Items = make(map[string]URLGroupsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]URLGroupsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -475,7 +481,7 @@ func (r *URLGroupsResource) createSubresources(ctx context.Context, state, plan 
 			body := bulk.toBody(ctx, URLGroups{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -592,7 +598,7 @@ func (r *URLGroupsResource) updateSubresources(ctx context.Context, state, plan 
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_urls.go
+++ b/internal/provider/resource_fmc_urls.go
@@ -148,17 +148,23 @@ func (r *URLsResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := URLs{}
-	state.Items = make(map[string]URLsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]URLsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -455,7 +461,7 @@ func (r *URLsResource) createSubresources(ctx context.Context, state, plan URLs,
 			body := bulk.toBody(ctx, URLs{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -572,7 +578,7 @@ func (r *URLsResource) updateSubresources(ctx context.Context, state, plan URLs,
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_vlan_tag_groups.go
+++ b/internal/provider/resource_fmc_vlan_tag_groups.go
@@ -172,17 +172,23 @@ func (r *VLANTagGroupsResource) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := VLANTagGroups{}
-	state.Items = make(map[string]VLANTagGroupsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]VLANTagGroupsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -479,7 +485,7 @@ func (r *VLANTagGroupsResource) createSubresources(ctx context.Context, state, p
 			body := bulk.toBody(ctx, VLANTagGroups{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -596,7 +602,7 @@ func (r *VLANTagGroupsResource) updateSubresources(ctx context.Context, state, p
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{

--- a/internal/provider/resource_fmc_vlan_tags.go
+++ b/internal/provider/resource_fmc_vlan_tags.go
@@ -152,17 +152,23 @@ func (r *VLANTagsResource) Create(ctx context.Context, req resource.CreateReques
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Create", plan.Id.ValueString()))
 
-	// Prepare state to track creation process
-	// Create request is split to multiple requests, where just subset of them may be successful
-	state := VLANTags{}
-	state.Items = make(map[string]VLANTagsItems, len(plan.Items))
+	//// Prepare state to track creation process. Create request is split to multiple requests, where just subset of them may be successful
+	// Copy fields, as those may contain domain information or other references
+	state := plan
+	// Create random ID to track bulk resource. This does not relate to FMC in any way
 	state.Id = types.StringValue(uuid.New().String())
-	state.Domain = plan.Domain
-
-	// Create object
+	// Erase all Items, those will be filled in after creation
+	state.Items = make(map[string]VLANTagsItems, len(plan.Items))
 	// Creation process is put in a separate function, as that same proces will be needed with `Update`
 	plan, diags = r.createSubresources(ctx, state, plan, reqMods...)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		// Save state for whatever was already created
+		diags = resp.State.Set(ctx, &plan)
+		tflog.Debug(ctx, fmt.Sprintf("%s: Create failed, some items might have been created", plan.Id.ValueString()))
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
@@ -459,7 +465,7 @@ func (r *VLANTagsResource) createSubresources(ctx context.Context, state, plan V
 			body := bulk.toBody(ctx, VLANTags{})
 
 			// Execute request
-			urlPath := bulk.getPath() + "?bulk=true"
+			urlPath := plan.getPath() + "?bulk=true"
 			res, err := r.client.Post(urlPath, body, reqMods...)
 			if err != nil {
 				return state, diag.Diagnostics{
@@ -576,7 +582,7 @@ func (r *VLANTagsResource) updateSubresources(ctx context.Context, state, plan V
 		tmpObject.Items[k] = v
 
 		body := tmpObject.toBodyNonBulk(ctx, state)
-		urlPath := tmpObject.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
+		urlPath := plan.getPath() + "/" + url.QueryEscape(v.Id.ValueString())
 		res, err := r.client.Put(urlPath, body, reqMods...)
 		if err != nil {
 			return state, diag.Diagnostics{


### PR DESCRIPTION
During `Create` of bulk resources, the object itself may contain some information i.a. Domain or Parent resource ID, which need to be preserved for set of sub-resources creation.