### PR TITLE
Tune MTU settings for tests

### DIFF
--- a/docs/resources/device_physical_interface.md
+++ b/docs/resources/device_physical_interface.md
@@ -20,7 +20,7 @@ resource "fmc_device_physical_interface" "example" {
   mode                 = "NONE"
   security_zone_id     = "76d24097-41c4-4558-a4d0-a8c07ac08470"
   name                 = "GigabitEthernet0/1"
-  mtu                  = 9000
+  mtu                  = 1400
   enable_sgt_propagate = false
   ipv4_static_address  = "10.1.1.1"
   ipv4_static_netmask  = "24"

--- a/examples/resources/fmc_device_physical_interface/resource.tf
+++ b/examples/resources/fmc_device_physical_interface/resource.tf
@@ -5,7 +5,7 @@ resource "fmc_device_physical_interface" "example" {
   mode                 = "NONE"
   security_zone_id     = "76d24097-41c4-4558-a4d0-a8c07ac08470"
   name                 = "GigabitEthernet0/1"
-  mtu                  = 9000
+  mtu                  = 1400
   enable_sgt_propagate = false
   ipv4_static_address  = "10.1.1.1"
   ipv4_static_netmask  = "24"

--- a/gen/definitions/device_physical_interface.yaml
+++ b/gen/definitions/device_physical_interface.yaml
@@ -79,7 +79,7 @@ attributes:
     description: Maximum transmission unit. Can only be used when logical_name is set.
     min_int: 64
     max_int: 9000
-    example: 9000
+    example: 1400
   - model_name: priority
     type: Int64
     description: Priority 0-65535. Can only be set for routed interfaces.

--- a/gen/definitions/device_vni_interface.yaml
+++ b/gen/definitions/device_vni_interface.yaml
@@ -200,7 +200,6 @@ test_prerequisites: |-
     name         = "GigabitEthernet0/1"
     mode         = "NONE"
     logical_name = "myinterface-0-1"
-    mtu          = 9000
   }
 
   resource "fmc_device_vtep_policy" "test" {

--- a/gen/definitions/device_vtep_policy.yaml
+++ b/gen/definitions/device_vtep_policy.yaml
@@ -105,7 +105,6 @@ test_prerequisites: |-
     name         = "GigabitEthernet0/1"
     mode         = "NONE"
     logical_name = "myinterface-0-1"
-    mtu          = 9000
   }
 
   variable "device_id" { default = null } // tests will set $TF_VAR_device_id

--- a/internal/provider/data_source_fmc_device_physical_interface_test.go
+++ b/internal/provider/data_source_fmc_device_physical_interface_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceFmcDevicePhysicalInterface(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "description", "my description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "mode", "NONE"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "name", "GigabitEthernet0/1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "mtu", "9000"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "mtu", "1400"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "ipv4_static_address", "10.1.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_device_physical_interface.test", "ipv4_static_netmask", "24"))
 	resource.Test(t, resource.TestCase{
@@ -80,7 +80,7 @@ func testAccDataSourceFmcDevicePhysicalInterfaceConfig() string {
 	config += `	description = "my description"` + "\n"
 	config += `	mode = "NONE"` + "\n"
 	config += `	name = "GigabitEthernet0/1"` + "\n"
-	config += `	mtu = 9000` + "\n"
+	config += `	mtu = 1400` + "\n"
 	config += `	ipv4_static_address = "10.1.1.1"` + "\n"
 	config += `	ipv4_static_netmask = "24"` + "\n"
 	config += `	ipv6_enable_ra = false` + "\n"
@@ -104,7 +104,7 @@ func testAccNamedDataSourceFmcDevicePhysicalInterfaceConfig() string {
 	config += `	description = "my description"` + "\n"
 	config += `	mode = "NONE"` + "\n"
 	config += `	name = "GigabitEthernet0/1"` + "\n"
-	config += `	mtu = 9000` + "\n"
+	config += `	mtu = 1400` + "\n"
 	config += `	ipv4_static_address = "10.1.1.1"` + "\n"
 	config += `	ipv4_static_netmask = "24"` + "\n"
 	config += `	ipv6_enable_ra = false` + "\n"

--- a/internal/provider/data_source_fmc_device_vni_interface_test.go
+++ b/internal/provider/data_source_fmc_device_vni_interface_test.go
@@ -67,7 +67,6 @@ resource "fmc_device_physical_interface" "test" {
   name         = "GigabitEthernet0/1"
   mode         = "NONE"
   logical_name = "myinterface-0-1"
-  mtu          = 9000
 }
 
 resource "fmc_device_vtep_policy" "test" {

--- a/internal/provider/data_source_fmc_device_vtep_policy_test.go
+++ b/internal/provider/data_source_fmc_device_vtep_policy_test.go
@@ -61,7 +61,6 @@ resource "fmc_device_physical_interface" "test" {
   name         = "GigabitEthernet0/1"
   mode         = "NONE"
   logical_name = "myinterface-0-1"
-  mtu          = 9000
 }
 
 variable "device_id" { default = null } // tests will set $TF_VAR_device_id

--- a/internal/provider/resource_fmc_device_physical_interface_test.go
+++ b/internal/provider/resource_fmc_device_physical_interface_test.go
@@ -39,7 +39,7 @@ func TestAccFmcDevicePhysicalInterface(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "description", "my description"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "mode", "NONE"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "name", "GigabitEthernet0/1"))
-	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "mtu", "9000"))
+	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "mtu", "1400"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "ipv4_static_address", "10.1.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_device_physical_interface.test", "ipv4_static_netmask", "24"))
 
@@ -98,7 +98,7 @@ func testAccFmcDevicePhysicalInterfaceConfig_all() string {
 	config += `	description = "my description"` + "\n"
 	config += `	mode = "NONE"` + "\n"
 	config += `	name = "GigabitEthernet0/1"` + "\n"
-	config += `	mtu = 9000` + "\n"
+	config += `	mtu = 1400` + "\n"
 	config += `	ipv4_static_address = "10.1.1.1"` + "\n"
 	config += `	ipv4_static_netmask = "24"` + "\n"
 	config += `	ipv6_enable_ra = false` + "\n"

--- a/internal/provider/resource_fmc_device_vni_interface_test.go
+++ b/internal/provider/resource_fmc_device_vni_interface_test.go
@@ -74,7 +74,6 @@ resource "fmc_device_physical_interface" "test" {
   name         = "GigabitEthernet0/1"
   mode         = "NONE"
   logical_name = "myinterface-0-1"
-  mtu          = 9000
 }
 
 resource "fmc_device_vtep_policy" "test" {

--- a/internal/provider/resource_fmc_device_vtep_policy_test.go
+++ b/internal/provider/resource_fmc_device_vtep_policy_test.go
@@ -68,7 +68,6 @@ resource "fmc_device_physical_interface" "test" {
   name         = "GigabitEthernet0/1"
   mode         = "NONE"
   logical_name = "myinterface-0-1"
-  mtu          = 9000
 }
 
 variable "device_id" { default = null } // tests will set $TF_VAR_device_id


### PR DESCRIPTION
Tune MTU settings, so the tests can be executed against FTDs deployed in cloud environments.