### PR TITLE
Fix: `fmc_device_bridge_group_interface`: `logical_name` is no longer `required` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-rc2 (Unreleased)
+
+- (Fix) `fmc_device_bridge_group_interface`: `logical_name` is no longer `required` field
+
 ## 2.0.0-rc1
 
 - (Change) Resource `fmc_device_ha_pair_physical_interface_mac_address` is deprecated and replaced with `fmc_device_ha_pair_failover_interface_mac_address`

--- a/docs/data-sources/device_bridge_group_interface.md
+++ b/docs/data-sources/device_bridge_group_interface.md
@@ -37,7 +37,7 @@ data "fmc_device_bridge_group_interface" "example" {
 - `arp_table_entries` (Attributes List) (see [below for nested schema](#nestedatt--arp_table_entries))
 - `bridge_group_id` (Number) Bridge Group Id.
 - `description` (String) Description of the object.
-- `ipv4_dhcp_obtain_route` (Boolean) Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must be null when using ipv4_static_address.
+- `ipv4_dhcp_obtain_route` (Boolean) Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must not be set when using ipv4_static_address. DHCP is not supported when firewall is in transparent mode.
 - `ipv4_static_address` (String) Static IPv4 address.
 - `ipv4_static_netmask` (String) Netmask for ipv4_static_address.
 - `ipv6_addresses` (Attributes List) (see [below for nested schema](#nestedatt--ipv6_addresses))

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 2.0.0-rc2 (Unreleased)
+
+- (Fix) `fmc_device_bridge_group_interface`: `logical_name` is no longer `required` field
+
 ## 2.0.0-rc1
 
 - (Change) Resource `fmc_device_ha_pair_physical_interface_mac_address` is deprecated and replaced with `fmc_device_ha_pair_failover_interface_mac_address`

--- a/docs/resources/device_bridge_group_interface.md
+++ b/docs/resources/device_bridge_group_interface.md
@@ -60,7 +60,7 @@ resource "fmc_device_bridge_group_interface" "example" {
 - `arp_table_entries` (Attributes List) (see [below for nested schema](#nestedatt--arp_table_entries))
 - `description` (String) Description of the object.
 - `domain` (String) Name of the FMC domain
-- `ipv4_dhcp_obtain_route` (Boolean) Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must be null when using ipv4_static_address.
+- `ipv4_dhcp_obtain_route` (Boolean) Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must not be set when using ipv4_static_address. DHCP is not supported when firewall is in transparent mode.
 - `ipv4_static_address` (String) Static IPv4 address.
 - `ipv4_static_netmask` (String) Netmask for ipv4_static_address.
 - `ipv6_addresses` (Attributes List) (see [below for nested schema](#nestedatt--ipv6_addresses))

--- a/docs/resources/device_bridge_group_interface.md
+++ b/docs/resources/device_bridge_group_interface.md
@@ -54,7 +54,6 @@ resource "fmc_device_bridge_group_interface" "example" {
 - `bridge_group_id` (Number) Bridge Group Id.
   - Range: `1`-`250`
 - `device_id` (String) Id of the parent device.
-- `logical_name` (String) Logical name of the Brige Group interface.
 
 ### Optional
 
@@ -72,6 +71,7 @@ resource "fmc_device_bridge_group_interface" "example" {
   - Range: `1000`-`3600000`
 - `ipv6_reachable_time` (Number) The amount of time (in Milliseconds) that a remote IPv6 node is considered reachable after a reachability confirmation event has occurred.
   - Range: `0`-`3600000`
+- `logical_name` (String) Logical name of the Brige Group interface.
 - `selected_interfaces` (Attributes List) List of interfaces that are part of the bridge group. (see [below for nested schema](#nestedatt--selected_interfaces))
 
 ### Read-Only

--- a/gen/definitions/device_bridge_group_interface.yaml
+++ b/gen/definitions/device_bridge_group_interface.yaml
@@ -79,7 +79,8 @@ attributes:
     description: >-
       Value `false` indicates to enable DHCPv4 without obtaining default route.
       Value `true` indicates to enable DHCPv4 and obtain the default route.
-      The ipv4_dhcp_obtain_route must be null when using ipv4_static_address.
+      The ipv4_dhcp_obtain_route must not be set when using ipv4_static_address.
+      DHCP is not supported when firewall is in transparent mode.
     exclude_example: true
     exclude_test: true
   # IPv6 address

--- a/gen/definitions/device_bridge_group_interface.yaml
+++ b/gen/definitions/device_bridge_group_interface.yaml
@@ -30,7 +30,6 @@ attributes:
     type: String
     description: Logical name of the Brige Group interface.
     example: my_bridge_group_interface
-    mandatory: true
   - model_name: description
     type: String
     description: Description of the object.

--- a/internal/provider/data_source_fmc_device_bridge_group_interface.go
+++ b/internal/provider/data_source_fmc_device_bridge_group_interface.go
@@ -121,7 +121,7 @@ func (d *DeviceBridgeGroupInterfaceDataSource) Schema(ctx context.Context, req d
 				Computed:            true,
 			},
 			"ipv4_dhcp_obtain_route": schema.BoolAttribute{
-				MarkdownDescription: "Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must be null when using ipv4_static_address.",
+				MarkdownDescription: "Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must not be set when using ipv4_static_address. DHCP is not supported when firewall is in transparent mode.",
 				Computed:            true,
 			},
 			"ipv6_addresses": schema.ListNestedAttribute{

--- a/internal/provider/resource_fmc_device_bridge_group_interface.go
+++ b/internal/provider/resource_fmc_device_bridge_group_interface.go
@@ -103,7 +103,7 @@ func (r *DeviceBridgeGroupInterfaceResource) Schema(ctx context.Context, req res
 			},
 			"logical_name": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Logical name of the Brige Group interface.").String,
-				Required:            true,
+				Optional:            true,
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Description of the object.").String,

--- a/internal/provider/resource_fmc_device_bridge_group_interface.go
+++ b/internal/provider/resource_fmc_device_bridge_group_interface.go
@@ -144,7 +144,7 @@ func (r *DeviceBridgeGroupInterfaceResource) Schema(ctx context.Context, req res
 				Optional:            true,
 			},
 			"ipv4_dhcp_obtain_route": schema.BoolAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must be null when using ipv4_static_address.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Value `false` indicates to enable DHCPv4 without obtaining default route. Value `true` indicates to enable DHCPv4 and obtain the default route. The ipv4_dhcp_obtain_route must not be set when using ipv4_static_address. DHCP is not supported when firewall is in transparent mode.").String,
 				Optional:            true,
 			},
 			"ipv6_addresses": schema.ListNestedAttribute{

--- a/internal/provider/resource_fmc_device_bridge_group_interface_test.go
+++ b/internal/provider/resource_fmc_device_bridge_group_interface_test.go
@@ -87,7 +87,6 @@ variable "interface_name" {default = null} // tests will set $TF_VAR_interface_n
 func testAccFmcDeviceBridgeGroupInterfaceConfig_minimum() string {
 	config := `resource "fmc_device_bridge_group_interface" "test" {` + "\n"
 	config += `	device_id = var.device_id` + "\n"
-	config += `	logical_name = "my_bridge_group_interface"` + "\n"
 	config += `	bridge_group_id = 100` + "\n"
 	config += `}` + "\n"
 	return config

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 2.0.0-rc2 (Unreleased)
+
+- (Fix) `fmc_device_bridge_group_interface`: `logical_name` is no longer `required` field
+
 ## 2.0.0-rc1
 
 - (Change) Resource `fmc_device_ha_pair_physical_interface_mac_address` is deprecated and replaced with `fmc_device_ha_pair_failover_interface_mac_address`


### PR DESCRIPTION
- (Fix) `fmc_device_bridge_group_interface`: `logical_name` is no longer `required` field

This addresses #254