### PR TITLE
Fix: `fmc_device`: add missing FTDv100 performance tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.0-rc4 (Unreleased)
 
 - (Fix) Corrected URL encoding for multiple resources
+- (Fix) `fmc_device`: add missing FTDv100 performance tier
 - (Enhancement) Add support for Security Cloud Control (SCC) Firewall Management Base URI
 
 ## 2.0.0-rc3

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,6 +10,7 @@ description: |-
 ## 2.0.0-rc4 (Unreleased)
 
 - (Fix) Corrected URL encoding for multiple resources
+- (Fix) `fmc_device`: add missing FTDv100 performance tier
 - (Enhancement) Add support for Security Cloud Control (SCC) Firewall Management Base URI
 
 ## 2.0.0-rc3

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -46,7 +46,7 @@ resource "fmc_device" "example" {
 - `nat_policy_id` (String) Id of the assigned FTD NAT policy.
 - `object_group_search` (Boolean) Enables Object Group Search
 - `performance_tier` (String) Performance tier for the managed device.
-  - Choices: `FTDv5`, `FTDv10`, `FTDv20`, `FTDv30`, `FTDv50`, `Legacy`
+  - Choices: `FTDv5`, `FTDv10`, `FTDv20`, `FTDv30`, `FTDv50`, `FTDv100`, `Legacy`
 - `prohibit_packet_transfer` (Boolean) Value true prohibits the device from sending packet data with events to the Firepower Management Center. Value false allows the transfer when a certain event is triggered. Not all traffic data is sent; connection events do not include a payload, only connection metadata.
 - `snort_engine` (String) SNORT engine version to be enabled.
   - Choices: `SNORT2`, `SNORT3`

--- a/gen/definitions/device.yaml
+++ b/gen/definitions/device.yaml
@@ -85,7 +85,7 @@ attributes:
     type: String
     write_only: true
     description: Performance tier for the managed device.
-    enum_values: [FTDv5, FTDv10, FTDv20, FTDv30, FTDv50, Legacy]
+    enum_values: [FTDv5, FTDv10, FTDv20, FTDv30, FTDv50, FTDv100, Legacy]
     example: FTDv5
   - model_name: snortEngine
     type: String

--- a/internal/provider/resource_fmc_device.go
+++ b/internal/provider/resource_fmc_device.go
@@ -131,10 +131,10 @@ func (r *DeviceResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional:            true,
 			},
 			"performance_tier": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Performance tier for the managed device.").AddStringEnumDescription("FTDv5", "FTDv10", "FTDv20", "FTDv30", "FTDv50", "Legacy").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Performance tier for the managed device.").AddStringEnumDescription("FTDv5", "FTDv10", "FTDv20", "FTDv30", "FTDv50", "FTDv100", "Legacy").String,
 				Optional:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("FTDv5", "FTDv10", "FTDv20", "FTDv30", "FTDv50", "Legacy"),
+					stringvalidator.OneOf("FTDv5", "FTDv10", "FTDv20", "FTDv30", "FTDv50", "FTDv100", "Legacy"),
 				},
 			},
 			"snort_engine": schema.StringAttribute{

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,6 +10,7 @@ description: |-
 ## 2.0.0-rc4 (Unreleased)
 
 - (Fix) Corrected URL encoding for multiple resources
+- (Fix) `fmc_device`: add missing FTDv100 performance tier
 - (Enhancement) Add support for Security Cloud Control (SCC) Firewall Management Base URI
 
 ## 2.0.0-rc3


### PR DESCRIPTION
(Fix) `fmc_device`: add missing FTDv100 performance tier