### PR TITLE
Fix: Remove `ValidateConfig` for `fmc_access_control_policy` and `fmc_ftd_nat_policy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-rc6 (Unreleased)
+
+- (Fix) Remove `ValidateConfig` for `fmc_access_control_policy` and `fmc_ftd_nat_policy`
+
 ## 2.0.0-rc5
 
 - (Enhancement) `fmc_access_control_policy` has new attributes `manage_rules` and `manage_categories` that disable managing (resource) or reading (data source) rules and categories

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 2.0.0-rc6 (Unreleased)
+
+- (Fix) Remove `ValidateConfig` for `fmc_access_control_policy` and `fmc_ftd_nat_policy`
+
 ## 2.0.0-rc5
 
 - (Enhancement) `fmc_access_control_policy` has new attributes `manage_rules` and `manage_categories` that disable managing (resource) or reading (data source) rules and categories

--- a/internal/provider/resource_fmc_access_control_policy.go
+++ b/internal/provider/resource_fmc_access_control_policy.go
@@ -727,37 +727,6 @@ func (r *AccessControlPolicyResource) Configure(_ context.Context, req resource.
 
 // End of section. //template:end model
 
-var _ resource.ResourceWithValidateConfig = &AccessControlPolicyResource{}
-
-func (p *AccessControlPolicyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data AccessControlPolicy
-
-	diags := req.Config.Get(ctx, &data)
-	if resp.Diagnostics.Append(diags...); resp.Diagnostics.HasError() {
-		return
-	}
-
-	// If manage_rules is not set, it defaults to true.
-	if !data.ManageRules.IsNull() && !data.ManageRules.ValueBool() && len(data.Rules) > 0 {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("rules"),
-			"Conflicting Configuration",
-			"Rules cannot be defined when manage_rules is set to false",
-		)
-		return
-	}
-
-	// If manage_categories is not set, it defaults to true.
-	if !data.ManageCategories.IsNull() && !data.ManageCategories.ValueBool() && len(data.Categories) > 0 {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("categories"),
-			"Conflicting Configuration",
-			"Categories cannot be defined when manage_categories is set to false",
-		)
-		return
-	}
-}
-
 func (r *AccessControlPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan AccessControlPolicy
 

--- a/internal/provider/resource_fmc_ftd_nat_policy.go
+++ b/internal/provider/resource_fmc_ftd_nat_policy.go
@@ -309,28 +309,6 @@ func (r *FTDNATPolicyResource) Configure(_ context.Context, req resource.Configu
 
 // End of section. //template:end model
 
-var _ resource.ResourceWithValidateConfig = &FTDNATPolicyResource{}
-
-func (p *FTDNATPolicyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data FTDNATPolicy
-
-	diags := req.Config.Get(ctx, &data)
-	if resp.Diagnostics.Append(diags...); resp.Diagnostics.HasError() {
-		return
-	}
-
-	// If manage_rules is not set, it defaults to true.
-	if !data.ManageRules.IsNull() && !data.ManageRules.ValueBool() && (len(data.AutoNatRules) > 0 || len(data.ManualNatRules) > 0) {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("rules"),
-			"Conflicting Configuration",
-			"Neither Manual nor Auto NAT Rules can be defined when manage_rules is set to false",
-		)
-		return
-	}
-
-}
-
 func (r *FTDNATPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan FTDNATPolicy
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 2.0.0-rc6 (Unreleased)
+
+- (Fix) Remove `ValidateConfig` for `fmc_access_control_policy` and `fmc_ftd_nat_policy`
+
 ## 2.0.0-rc5
 
 - (Enhancement) `fmc_access_control_policy` has new attributes `manage_rules` and `manage_categories` that disable managing (resource) or reading (data source) rules and categories


### PR DESCRIPTION
Remove `ValidateConfig` for `fmc_access_control_policy` and `fmc_ftd_nat_policy`, as this validator may cause problems in case Terraform Modules are build on top of it.