### PR TITLE
Prefilter policy is not assigned to Access Control Policy on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.0.0 (Unreleased)
 
+- (Fix) Prefilter policy is not assigned to Access Control Policy on creation
 - (Enhancement) Add support for `fmc_secure_client_posture_package` resource and data source
 - (Enhancement) Add support for `fmc_dynamic_access_policy` resource and data source (no records support)
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## 2.0.0 (Unreleased)
 
+- (Fix) Prefilter policy is not assigned to Access Control Policy on creation
 - (Enhancement) Add support for `fmc_secure_client_posture_package` resource and data source
 - (Enhancement) Add support for `fmc_dynamic_access_policy` resource and data source (no records support)
 

--- a/gen/definitions/access_control_policy.yaml
+++ b/gen/definitions/access_control_policy.yaml
@@ -78,7 +78,7 @@ attributes:
     description: >-
       Id of the Prefilter Policy.
     example: 35e197ca-33a8-11ef-b2d1-d98ae17766e7
-    exclude_test: true
+    test_value: fmc_prefilter_policy.test.id
   - model_name: syslogSeverity
     data_path: [defaultAction]
     tf_name: default_action_syslog_severity
@@ -817,4 +817,9 @@ test_prerequisites: |-
     name      = "fmc_access_control_policy_vlan_tag"
     start_tag = "10"
     end_tag   = "11"
+  }
+
+  resource "fmc_prefilter_policy" "test" {
+    name                              = "my_prefilter_policy"
+    default_action                    = "BLOCK_TUNNELS"
   }

--- a/internal/provider/data_source_fmc_access_control_policy_test.go
+++ b/internal/provider/data_source_fmc_access_control_policy_test.go
@@ -104,6 +104,11 @@ resource "fmc_vlan_tag" "test" {
   start_tag = "10"
   end_tag   = "11"
 }
+
+resource "fmc_prefilter_policy" "test" {
+  name                              = "my_prefilter_policy"
+  default_action                    = "BLOCK_TUNNELS"
+}
 `
 
 // End of section. //template:end testPrerequisites
@@ -118,6 +123,7 @@ func testAccDataSourceFmcAccessControlPolicyConfig() string {
 	config += `	default_action_log_begin = true` + "\n"
 	config += `	default_action_log_end = false` + "\n"
 	config += `	default_action_send_events_to_fmc = true` + "\n"
+	config += `	prefilter_policy_id = fmc_prefilter_policy.test.id` + "\n"
 	config += `	default_action_syslog_severity = "DEBUG"` + "\n"
 	config += `	manage_categories = true` + "\n"
 	config += `	categories = [{` + "\n"
@@ -203,6 +209,7 @@ func testAccNamedDataSourceFmcAccessControlPolicyConfig() string {
 	config += `	default_action_log_begin = true` + "\n"
 	config += `	default_action_log_end = false` + "\n"
 	config += `	default_action_send_events_to_fmc = true` + "\n"
+	config += `	prefilter_policy_id = fmc_prefilter_policy.test.id` + "\n"
 	config += `	default_action_syslog_severity = "DEBUG"` + "\n"
 	config += `	manage_categories = true` + "\n"
 	config += `	categories = [{` + "\n"

--- a/internal/provider/resource_fmc_access_control_policy_test.go
+++ b/internal/provider/resource_fmc_access_control_policy_test.go
@@ -113,6 +113,11 @@ resource "fmc_vlan_tag" "test" {
   start_tag = "10"
   end_tag   = "11"
 }
+
+resource "fmc_prefilter_policy" "test" {
+  name                              = "my_prefilter_policy"
+  default_action                    = "BLOCK_TUNNELS"
+}
 `
 
 // End of section. //template:end testPrerequisites
@@ -139,6 +144,7 @@ func testAccFmcAccessControlPolicyConfig_all() string {
 	config += `	default_action_log_begin = true` + "\n"
 	config += `	default_action_log_end = false` + "\n"
 	config += `	default_action_send_events_to_fmc = true` + "\n"
+	config += `	prefilter_policy_id = fmc_prefilter_policy.test.id` + "\n"
 	config += `	default_action_syslog_severity = "DEBUG"` + "\n"
 	config += `	manage_categories = true` + "\n"
 	config += `	categories = [{` + "\n"
@@ -210,7 +216,7 @@ func testAccFmcAccessControlPolicyConfig_all() string {
 
 // End of section. //template:end testAccConfigAll
 
-func TestNewValidAccessControlPolicy(t *testing.T) {
+func TestAccFmcAccessControlPolicy_NewValid(t *testing.T) {
 
 	steps := []resource.TestStep{{
 		Config: `resource fmc_access_control_policy step1 {` + "\n" +

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## 2.0.0 (Unreleased)
 
+- (Fix) Prefilter policy is not assigned to Access Control Policy on creation
 - (Enhancement) Add support for `fmc_secure_client_posture_package` resource and data source
 - (Enhancement) Add support for `fmc_dynamic_access_policy` resource and data source (no records support)
 


### PR DESCRIPTION
(Fix) Prefilter policy is not assigned to Access Control Policy on creation