### PR TITLE
Fix: Remote Access VPN stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - (Fix) Prefilter policy is not assigned to Access Control Policy on creation
 - (Fix) `fmc_policy_assignment` for Health Policies on FMC 7.6 and later does not work correctly
+- (Fix) Attempt to stabilize VPN Remote Access resources
 - (Change) Remove `ValidateConfig` for `fmc_vpn_ra_connection_profiles`
 - (Change) Remove `fmc_device_ha_pair_physical_interface_mac_address` resource and data source
 - (Change) `fmc_file_analysis`: `store_files` attribute allowed values update

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -11,6 +11,7 @@ description: |-
 
 - (Fix) Prefilter policy is not assigned to Access Control Policy on creation
 - (Fix) `fmc_policy_assignment` for Health Policies on FMC 7.6 and later does not work correctly
+- (Fix) Attempt to stabilize VPN Remote Access resources
 - (Change) Remove `ValidateConfig` for `fmc_vpn_ra_connection_profiles`
 - (Change) Remove `fmc_device_ha_pair_physical_interface_mac_address` resource and data source
 - (Change) `fmc_file_analysis`: `store_files` attribute allowed values update

--- a/gen/definitions/vpn_ra_address_assignment_policy.yaml
+++ b/gen/definitions/vpn_ra_address_assignment_policy.yaml
@@ -1,4 +1,6 @@
-# Manual resource - toBodyPutDelete
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - toBodyPutDelete, Read, Create, Update
+# Manual data source - Read
 ---
 name: VPN RA Address Assignment Policy
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/addressassignmentsettings

--- a/gen/definitions/vpn_ra_certificate_map.yaml
+++ b/gen/definitions/vpn_ra_certificate_map.yaml
@@ -1,4 +1,7 @@
 # FMCBUG CSCwq59110 FMC API: Cannot set Default Connection Profile over API (policy/ravpns/{containerUUID}/certificatemapsettings)
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - Read, Create, Update
+# Manual data source - Read
 ---
 name: VPN RA Certificate Map
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/certificatemapsettings

--- a/gen/definitions/vpn_ra_connection_profiles.yaml
+++ b/gen/definitions/vpn_ra_connection_profiles.yaml
@@ -1,5 +1,7 @@
-# Manual resource - createSubresources, deleteSubresources
 # FMCBUG CSCwq59124 FMC API: Multiple fields malfunction in /policy/ravpns/{containerUUID}/connectionprofiles endpoint
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - createSubresources, deleteSubresources, Read, Create
+# Manual data source - Read
 ---
 name: VPN RA Connection Profiles
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/connectionprofiles

--- a/gen/definitions/vpn_ra_ipsec_crypto_map.yaml
+++ b/gen/definitions/vpn_ra_ipsec_crypto_map.yaml
@@ -1,3 +1,6 @@
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - Read, Update, Create
+# Manual data source - Read
 ---
 name: VPN RA IPSec Crypto Map
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/ipseccryptomaps

--- a/gen/definitions/vpn_ra_ipsec_ike_parameters.yaml
+++ b/gen/definitions/vpn_ra_ipsec_ike_parameters.yaml
@@ -1,3 +1,6 @@
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - Read, Create, Update
+# Manual data source - Read
 ---
 name: VPN RA IPSec IKE Parameters
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/ipsecadvancedsettings

--- a/gen/definitions/vpn_ra_ldap_attribute_map.yaml
+++ b/gen/definitions/vpn_ra_ldap_attribute_map.yaml
@@ -1,3 +1,6 @@
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - Read, Create, Update
+# Manual data source - Read
 ---
 name: VPN RA LDAP Attribute Map
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/ldapattributemaps

--- a/gen/definitions/vpn_ra_load_balancing.yaml
+++ b/gen/definitions/vpn_ra_load_balancing.yaml
@@ -1,3 +1,6 @@
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - Read, Create, Update
+# Manual data source - Read
 ---
 name: VPN RA Load Balancing
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/loadbalancesettings

--- a/gen/definitions/vpn_ra_secure_client_customization.yaml
+++ b/gen/definitions/vpn_ra_secure_client_customization.yaml
@@ -1,3 +1,6 @@
+# FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+# Manual resource - Read, Create, Update
+# Manual data source - Read
 ---
 name: VPN RA Secure Client Customization
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/policy/ravpns/%v/secureclientcustomizationsettings

--- a/internal/provider/data_source_fmc_vpn_ra_certificate_map.go
+++ b/internal/provider/data_source_fmc_vpn_ra_certificate_map.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -112,8 +114,6 @@ func (d *VPNRACertificateMapDataSource) Configure(_ context.Context, req datasou
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin read
-
 func (d *VPNRACertificateMapDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config VPNRACertificateMap
 
@@ -132,7 +132,21 @@ func (d *VPNRACertificateMapDataSource) Read(ctx context.Context, req datasource
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	urlPath := config.getPath() + "/" + url.QueryEscape(config.Id.ValueString())
-	res, err := d.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = d.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
 		return
@@ -145,5 +159,3 @@ func (d *VPNRACertificateMapDataSource) Read(ctx context.Context, req datasource
 	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end read

--- a/internal/provider/data_source_fmc_vpn_ra_ipsec_ike_parameters.go
+++ b/internal/provider/data_source_fmc_vpn_ra_ipsec_ike_parameters.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -128,8 +130,6 @@ func (d *VPNRAIPSecIKEParametersDataSource) Configure(_ context.Context, req dat
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin read
-
 func (d *VPNRAIPSecIKEParametersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config VPNRAIPSecIKEParameters
 
@@ -148,7 +148,21 @@ func (d *VPNRAIPSecIKEParametersDataSource) Read(ctx context.Context, req dataso
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	urlPath := config.getPath() + "/" + url.QueryEscape(config.Id.ValueString())
-	res, err := d.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = d.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
 		return
@@ -161,5 +175,3 @@ func (d *VPNRAIPSecIKEParametersDataSource) Read(ctx context.Context, req dataso
 	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end read

--- a/internal/provider/data_source_fmc_vpn_ra_ldap_attribute_map.go
+++ b/internal/provider/data_source_fmc_vpn_ra_ldap_attribute_map.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -132,8 +134,6 @@ func (d *VPNRALDAPAttributeMapDataSource) Configure(_ context.Context, req datas
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin read
-
 func (d *VPNRALDAPAttributeMapDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config VPNRALDAPAttributeMap
 
@@ -152,7 +152,21 @@ func (d *VPNRALDAPAttributeMapDataSource) Read(ctx context.Context, req datasour
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	urlPath := config.getPath() + "/" + url.QueryEscape(config.Id.ValueString())
-	res, err := d.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = d.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
 		return
@@ -165,5 +179,3 @@ func (d *VPNRALDAPAttributeMapDataSource) Read(ctx context.Context, req datasour
 	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end read

--- a/internal/provider/data_source_fmc_vpn_ra_load_balancing.go
+++ b/internal/provider/data_source_fmc_vpn_ra_load_balancing.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -125,8 +127,6 @@ func (d *VPNRALoadBalancingDataSource) Configure(_ context.Context, req datasour
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin read
-
 func (d *VPNRALoadBalancingDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config VPNRALoadBalancing
 
@@ -145,7 +145,21 @@ func (d *VPNRALoadBalancingDataSource) Read(ctx context.Context, req datasource.
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	urlPath := config.getPath() + "/" + url.QueryEscape(config.Id.ValueString())
-	res, err := d.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = d.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
 		return
@@ -158,5 +172,3 @@ func (d *VPNRALoadBalancingDataSource) Read(ctx context.Context, req datasource.
 	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end read

--- a/internal/provider/data_source_fmc_vpn_ra_secure_client_customization.go
+++ b/internal/provider/data_source_fmc_vpn_ra_secure_client_customization.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -160,8 +162,6 @@ func (d *VPNRASecureClientCustomizationDataSource) Configure(_ context.Context, 
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin read
-
 func (d *VPNRASecureClientCustomizationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config VPNRASecureClientCustomization
 
@@ -180,7 +180,21 @@ func (d *VPNRASecureClientCustomizationDataSource) Read(ctx context.Context, req
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", config.Id.String()))
 	urlPath := config.getPath() + "/" + url.QueryEscape(config.Id.ValueString())
-	res, err := d.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = d.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
 		return
@@ -193,5 +207,3 @@ func (d *VPNRASecureClientCustomizationDataSource) Read(ctx context.Context, req
 	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end read

--- a/internal/provider/model_fmc_vpn_ra_connection_profiles.go
+++ b/internal/provider/model_fmc_vpn_ra_connection_profiles.go
@@ -1059,11 +1059,3 @@ func (data VPNRAConnectionProfiles) toBodyNonBulk(ctx context.Context, state VPN
 }
 
 // End of section. //template:end toBodyNonBulk
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBody
-
-// End of section. //template:end adjustBody
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBodyBulk
-
-// End of section. //template:end adjustBodyBulk

--- a/internal/provider/model_fmc_vpn_ra_ipsec_crypto_map.go
+++ b/internal/provider/model_fmc_vpn_ra_ipsec_crypto_map.go
@@ -379,31 +379,3 @@ func (data *VPNRAIPSecCryptoMap) fromBodyUnknowns(ctx context.Context, res gjson
 }
 
 // End of section. //template:end fromBodyUnknowns
-
-// Section below is generated&owned by "gen/generator.go". //template:begin Clone
-
-// End of section. //template:end Clone
-
-// Section below is generated&owned by "gen/generator.go". //template:begin toBodyNonBulk
-
-// End of section. //template:end toBodyNonBulk
-
-// Section below is generated&owned by "gen/generator.go". //template:begin findObjectsToBeReplaced
-
-// End of section. //template:end findObjectsToBeReplaced
-
-// Section below is generated&owned by "gen/generator.go". //template:begin clearItemIds
-
-// End of section. //template:end clearItemIds
-
-// Section below is generated&owned by "gen/generator.go". //template:begin toBodyPutDelete
-
-// End of section. //template:end toBodyPutDelete
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBody
-
-// End of section. //template:end adjustBody
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBodyBulk
-
-// End of section. //template:end adjustBodyBulk

--- a/internal/provider/model_fmc_vpn_ra_ipsec_ike_parameters.go
+++ b/internal/provider/model_fmc_vpn_ra_ipsec_ike_parameters.go
@@ -250,33 +250,9 @@ func (data *VPNRAIPSecIKEParameters) fromBodyUnknowns(ctx context.Context, res g
 
 // End of section. //template:end fromBodyUnknowns
 
-// Section below is generated&owned by "gen/generator.go". //template:begin Clone
-
-// End of section. //template:end Clone
-
-// Section below is generated&owned by "gen/generator.go". //template:begin toBodyNonBulk
-
-// End of section. //template:end toBodyNonBulk
-
-// Section below is generated&owned by "gen/generator.go". //template:begin findObjectsToBeReplaced
-
-// End of section. //template:end findObjectsToBeReplaced
-
-// Section below is generated&owned by "gen/generator.go". //template:begin clearItemIds
-
-// End of section. //template:end clearItemIds
-
-// Section below is generated&owned by "gen/generator.go". //template:begin toBodyPutDelete
-
-// End of section. //template:end toBodyPutDelete
-
 func (data VPNRAIPSecIKEParameters) adjustBody(ctx context.Context, req string) string {
 	if !data.IpsecPathMaximumTransmissionUnitAgingResetInterval.IsNull() {
 		req, _ = sjson.Set(req, "ipsecsettings.maximumTransmissionUnitAging.enabled", true)
 	}
 	return req
 }
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBodyBulk
-
-// End of section. //template:end adjustBodyBulk

--- a/internal/provider/model_fmc_vpn_ra_ldap_attribute_map.go
+++ b/internal/provider/model_fmc_vpn_ra_ldap_attribute_map.go
@@ -356,22 +356,6 @@ func (data *VPNRALDAPAttributeMap) fromBodyUnknowns(ctx context.Context, res gjs
 
 // End of section. //template:end fromBodyUnknowns
 
-// Section below is generated&owned by "gen/generator.go". //template:begin Clone
-
-// End of section. //template:end Clone
-
-// Section below is generated&owned by "gen/generator.go". //template:begin toBodyNonBulk
-
-// End of section. //template:end toBodyNonBulk
-
-// Section below is generated&owned by "gen/generator.go". //template:begin findObjectsToBeReplaced
-
-// End of section. //template:end findObjectsToBeReplaced
-
-// Section below is generated&owned by "gen/generator.go". //template:begin clearItemIds
-
-// End of section. //template:end clearItemIds
-
 // Section below is generated&owned by "gen/generator.go". //template:begin toBodyPutDelete
 
 // toBodyPutDelete is used to create the body for PUT requests to clear the resource state
@@ -387,11 +371,3 @@ func (data VPNRALDAPAttributeMap) toBodyPutDelete(ctx context.Context) string {
 }
 
 // End of section. //template:end toBodyPutDelete
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBody
-
-// End of section. //template:end adjustBody
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBodyBulk
-
-// End of section. //template:end adjustBodyBulk

--- a/internal/provider/model_fmc_vpn_ra_load_balancing.go
+++ b/internal/provider/model_fmc_vpn_ra_load_balancing.go
@@ -226,22 +226,6 @@ func (data *VPNRALoadBalancing) fromBodyUnknowns(ctx context.Context, res gjson.
 
 // End of section. //template:end fromBodyUnknowns
 
-// Section below is generated&owned by "gen/generator.go". //template:begin Clone
-
-// End of section. //template:end Clone
-
-// Section below is generated&owned by "gen/generator.go". //template:begin toBodyNonBulk
-
-// End of section. //template:end toBodyNonBulk
-
-// Section below is generated&owned by "gen/generator.go". //template:begin findObjectsToBeReplaced
-
-// End of section. //template:end findObjectsToBeReplaced
-
-// Section below is generated&owned by "gen/generator.go". //template:begin clearItemIds
-
-// End of section. //template:end clearItemIds
-
 // Section below is generated&owned by "gen/generator.go". //template:begin toBodyPutDelete
 
 // toBodyPutDelete is used to create the body for PUT requests to clear the resource state
@@ -257,11 +241,3 @@ func (data VPNRALoadBalancing) toBodyPutDelete(ctx context.Context) string {
 }
 
 // End of section. //template:end toBodyPutDelete
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBody
-
-// End of section. //template:end adjustBody
-
-// Section below is generated&owned by "gen/generator.go". //template:begin adjustBodyBulk
-
-// End of section. //template:end adjustBodyBulk

--- a/internal/provider/resource_fmc_vpn_ra.go
+++ b/internal/provider/resource_fmc_vpn_ra.go
@@ -309,13 +309,13 @@ func (r *VPNRAResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.Id = types.StringValue(res.Get("id").String())
 	plan.fromBodyUnknowns(ctx, res)
 
+	// Wait for the FMC to process the new object and create subresources
+	time.Sleep(5 * time.Second)
+
 	tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
-
-	// Wait for the FMC to process the new object and create subresources
-	time.Sleep(5 * time.Second)
 
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
@@ -452,15 +452,3 @@ func (r *VPNRAResource) ImportState(ctx context.Context, req resource.ImportStat
 }
 
 // End of section. //template:end import
-
-// Section below is generated&owned by "gen/generator.go". //template:begin createSubresources
-
-// End of section. //template:end createSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin deleteSubresources
-
-// End of section. //template:end deleteSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
-
-// End of section. //template:end updateSubresources

--- a/internal/provider/resource_fmc_vpn_ra_address_assignment_policy.go
+++ b/internal/provider/resource_fmc_vpn_ra_address_assignment_policy.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -37,6 +38,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-fmc"
+	"github.com/tidwall/gjson"
 )
 
 // End of section. //template:end imports
@@ -148,8 +150,6 @@ func (r *VPNRAAddressAssignmentPolicyResource) Configure(_ context.Context, req 
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin create
-
 func (r *VPNRAAddressAssignmentPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan VPNRAAddressAssignmentPolicy
 
@@ -166,17 +166,39 @@ func (r *VPNRAAddressAssignmentPolicyResource) Create(ctx context.Context, req r
 	}
 	//// ID needs to be retrieved from FMC, however we are expecting exactly one object
 	// Get objects from FMC
-	resId, err := r.client.Get(plan.getPath(), reqMods...)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
-		return
-	}
 
-	// Check if exactly one object is returned
-	val := resId.Get("items").Array()
-	if len(val) != 1 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
-		return
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var resId, res fmc.Res
+	var err error
+	var val []gjson.Result
+	for range 5 {
+		for range 5 {
+			resId, err = r.client.Get(plan.getPath(), reqMods...)
+			if err == nil {
+				break
+			}
+			if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
+			return
+		}
+
+		// Check if exactly one object is returned
+		val = resId.Get("items").Array()
+		if len(val) == 0 {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if len(val) != 1 {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
+			return
+		}
+		break
 	}
 
 	// Extract ID from the object
@@ -191,7 +213,17 @@ func (r *VPNRAAddressAssignmentPolicyResource) Create(ctx context.Context, req r
 
 	// Create object
 	body := plan.toBody(ctx, VPNRAAddressAssignmentPolicy{})
-	res, err := r.client.Put(plan.getPath()+"/"+url.PathEscape(plan.Id.ValueString()), body, reqMods...)
+	urlPath := plan.getPath() + "/" + url.PathEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (POST/PUT), got error: %s, %s", err, res.String()))
 		return
@@ -206,10 +238,6 @@ func (r *VPNRAAddressAssignmentPolicyResource) Create(ctx context.Context, req r
 
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
-
-// End of section. //template:end create
-
-// Section below is generated&owned by "gen/generator.go". //template:begin read
 
 func (r *VPNRAAddressAssignmentPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state VPNRAAddressAssignmentPolicy
@@ -229,7 +257,20 @@ func (r *VPNRAAddressAssignmentPolicyResource) Read(ctx context.Context, req res
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", state.Id.String()))
 
 	urlPath := state.getPath() + "/" + url.QueryEscape(state.Id.ValueString())
-	res, err := r.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = r.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 
 	if err != nil && strings.Contains(err.Error(), "StatusCode 404") {
 		resp.State.RemoveResource(ctx)
@@ -259,10 +300,6 @@ func (r *VPNRAAddressAssignmentPolicyResource) Read(ctx context.Context, req res
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
 
-// End of section. //template:end read
-
-// Section below is generated&owned by "gen/generator.go". //template:begin update
-
 func (r *VPNRAAddressAssignmentPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state VPNRAAddressAssignmentPolicy
 
@@ -287,7 +324,20 @@ func (r *VPNRAAddressAssignmentPolicyResource) Update(ctx context.Context, req r
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Update", plan.Id.ValueString()))
 
 	body := plan.toBody(ctx, state)
-	res, err := r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString()), body, reqMods...)
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	urlPath := plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
 		return
@@ -298,8 +348,6 @@ func (r *VPNRAAddressAssignmentPolicyResource) Update(ctx context.Context, req r
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end update
 
 // Section below is generated&owned by "gen/generator.go". //template:begin delete
 
@@ -352,15 +400,3 @@ func (r *VPNRAAddressAssignmentPolicyResource) ImportState(ctx context.Context, 
 }
 
 // End of section. //template:end import
-
-// Section below is generated&owned by "gen/generator.go". //template:begin createSubresources
-
-// End of section. //template:end createSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin deleteSubresources
-
-// End of section. //template:end deleteSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
-
-// End of section. //template:end updateSubresources

--- a/internal/provider/resource_fmc_vpn_ra_certificate_map.go
+++ b/internal/provider/resource_fmc_vpn_ra_certificate_map.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -33,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-fmc"
+	"github.com/tidwall/gjson"
 )
 
 // End of section. //template:end imports
@@ -129,8 +131,6 @@ func (r *VPNRACertificateMapResource) Configure(_ context.Context, req resource.
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin create
-
 func (r *VPNRACertificateMapResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan VPNRACertificateMap
 
@@ -147,17 +147,39 @@ func (r *VPNRACertificateMapResource) Create(ctx context.Context, req resource.C
 	}
 	//// ID needs to be retrieved from FMC, however we are expecting exactly one object
 	// Get objects from FMC
-	resId, err := r.client.Get(plan.getPath(), reqMods...)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
-		return
-	}
 
-	// Check if exactly one object is returned
-	val := resId.Get("items").Array()
-	if len(val) != 1 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
-		return
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var resId, res fmc.Res
+	var err error
+	var val []gjson.Result
+	for range 5 {
+		for range 5 {
+			resId, err = r.client.Get(plan.getPath(), reqMods...)
+			if err == nil {
+				break
+			}
+			if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
+			return
+		}
+
+		// Check if exactly one object is returned
+		val = resId.Get("items").Array()
+		if len(val) == 0 {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if len(val) != 1 {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
+			return
+		}
+		break
 	}
 
 	// Extract ID from the object
@@ -172,7 +194,17 @@ func (r *VPNRACertificateMapResource) Create(ctx context.Context, req resource.C
 
 	// Create object
 	body := plan.toBody(ctx, VPNRACertificateMap{})
-	res, err := r.client.Put(plan.getPath()+"/"+url.PathEscape(plan.Id.ValueString()), body, reqMods...)
+	urlPath := plan.getPath() + "/" + url.PathEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (POST/PUT), got error: %s, %s", err, res.String()))
 		return
@@ -187,10 +219,6 @@ func (r *VPNRACertificateMapResource) Create(ctx context.Context, req resource.C
 
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
-
-// End of section. //template:end create
-
-// Section below is generated&owned by "gen/generator.go". //template:begin read
 
 func (r *VPNRACertificateMapResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state VPNRACertificateMap
@@ -210,7 +238,20 @@ func (r *VPNRACertificateMapResource) Read(ctx context.Context, req resource.Rea
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", state.Id.String()))
 
 	urlPath := state.getPath() + "/" + url.QueryEscape(state.Id.ValueString())
-	res, err := r.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = r.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 
 	if err != nil && strings.Contains(err.Error(), "StatusCode 404") {
 		resp.State.RemoveResource(ctx)
@@ -240,10 +281,6 @@ func (r *VPNRACertificateMapResource) Read(ctx context.Context, req resource.Rea
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
 
-// End of section. //template:end read
-
-// Section below is generated&owned by "gen/generator.go". //template:begin update
-
 func (r *VPNRACertificateMapResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state VPNRACertificateMap
 
@@ -268,7 +305,20 @@ func (r *VPNRACertificateMapResource) Update(ctx context.Context, req resource.U
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Update", plan.Id.ValueString()))
 
 	body := plan.toBody(ctx, state)
-	res, err := r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString()), body, reqMods...)
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	urlPath := plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
 		return
@@ -279,8 +329,6 @@ func (r *VPNRACertificateMapResource) Update(ctx context.Context, req resource.U
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end update
 
 // Section below is generated&owned by "gen/generator.go". //template:begin delete
 
@@ -333,15 +381,3 @@ func (r *VPNRACertificateMapResource) ImportState(ctx context.Context, req resou
 }
 
 // End of section. //template:end import
-
-// Section below is generated&owned by "gen/generator.go". //template:begin createSubresources
-
-// End of section. //template:end createSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin deleteSubresources
-
-// End of section. //template:end deleteSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
-
-// End of section. //template:end updateSubresources

--- a/internal/provider/resource_fmc_vpn_ra_ldap_attribute_map.go
+++ b/internal/provider/resource_fmc_vpn_ra_ldap_attribute_map.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -33,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-fmc"
+	"github.com/tidwall/gjson"
 )
 
 // End of section. //template:end imports
@@ -149,8 +151,6 @@ func (r *VPNRALDAPAttributeMapResource) Configure(_ context.Context, req resourc
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin create
-
 func (r *VPNRALDAPAttributeMapResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan VPNRALDAPAttributeMap
 
@@ -167,17 +167,39 @@ func (r *VPNRALDAPAttributeMapResource) Create(ctx context.Context, req resource
 	}
 	//// ID needs to be retrieved from FMC, however we are expecting exactly one object
 	// Get objects from FMC
-	resId, err := r.client.Get(plan.getPath(), reqMods...)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
-		return
-	}
 
-	// Check if exactly one object is returned
-	val := resId.Get("items").Array()
-	if len(val) != 1 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
-		return
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var resId, res fmc.Res
+	var err error
+	var val []gjson.Result
+	for range 5 {
+		for range 5 {
+			resId, err = r.client.Get(plan.getPath(), reqMods...)
+			if err == nil {
+				break
+			}
+			if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
+			return
+		}
+
+		// Check if exactly one object is returned
+		val = resId.Get("items").Array()
+		if len(val) == 0 {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if len(val) != 1 {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
+			return
+		}
+		break
 	}
 
 	// Extract ID from the object
@@ -192,7 +214,17 @@ func (r *VPNRALDAPAttributeMapResource) Create(ctx context.Context, req resource
 
 	// Create object
 	body := plan.toBody(ctx, VPNRALDAPAttributeMap{})
-	res, err := r.client.Put(plan.getPath()+"/"+url.PathEscape(plan.Id.ValueString()), body, reqMods...)
+	urlPath := plan.getPath() + "/" + url.PathEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (POST/PUT), got error: %s, %s", err, res.String()))
 		return
@@ -207,10 +239,6 @@ func (r *VPNRALDAPAttributeMapResource) Create(ctx context.Context, req resource
 
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
-
-// End of section. //template:end create
-
-// Section below is generated&owned by "gen/generator.go". //template:begin read
 
 func (r *VPNRALDAPAttributeMapResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state VPNRALDAPAttributeMap
@@ -230,7 +258,20 @@ func (r *VPNRALDAPAttributeMapResource) Read(ctx context.Context, req resource.R
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", state.Id.String()))
 
 	urlPath := state.getPath() + "/" + url.QueryEscape(state.Id.ValueString())
-	res, err := r.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = r.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 
 	if err != nil && strings.Contains(err.Error(), "StatusCode 404") {
 		resp.State.RemoveResource(ctx)
@@ -260,10 +301,6 @@ func (r *VPNRALDAPAttributeMapResource) Read(ctx context.Context, req resource.R
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
 
-// End of section. //template:end read
-
-// Section below is generated&owned by "gen/generator.go". //template:begin update
-
 func (r *VPNRALDAPAttributeMapResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state VPNRALDAPAttributeMap
 
@@ -288,7 +325,20 @@ func (r *VPNRALDAPAttributeMapResource) Update(ctx context.Context, req resource
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Update", plan.Id.ValueString()))
 
 	body := plan.toBody(ctx, state)
-	res, err := r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString()), body, reqMods...)
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	urlPath := plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
 		return
@@ -299,8 +349,6 @@ func (r *VPNRALDAPAttributeMapResource) Update(ctx context.Context, req resource
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end update
 
 // Section below is generated&owned by "gen/generator.go". //template:begin delete
 
@@ -353,15 +401,3 @@ func (r *VPNRALDAPAttributeMapResource) ImportState(ctx context.Context, req res
 }
 
 // End of section. //template:end import
-
-// Section below is generated&owned by "gen/generator.go". //template:begin createSubresources
-
-// End of section. //template:end createSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin deleteSubresources
-
-// End of section. //template:end deleteSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
-
-// End of section. //template:end updateSubresources

--- a/internal/provider/resource_fmc_vpn_ra_load_balancing.go
+++ b/internal/provider/resource_fmc_vpn_ra_load_balancing.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -36,6 +37,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-fmc"
+	"github.com/tidwall/gjson"
 )
 
 // End of section. //template:end imports
@@ -154,8 +156,6 @@ func (r *VPNRALoadBalancingResource) Configure(_ context.Context, req resource.C
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin create
-
 func (r *VPNRALoadBalancingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan VPNRALoadBalancing
 
@@ -172,17 +172,39 @@ func (r *VPNRALoadBalancingResource) Create(ctx context.Context, req resource.Cr
 	}
 	//// ID needs to be retrieved from FMC, however we are expecting exactly one object
 	// Get objects from FMC
-	resId, err := r.client.Get(plan.getPath(), reqMods...)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
-		return
-	}
 
-	// Check if exactly one object is returned
-	val := resId.Get("items").Array()
-	if len(val) != 1 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
-		return
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var resId, res fmc.Res
+	var err error
+	var val []gjson.Result
+	for range 5 {
+		for range 5 {
+			resId, err = r.client.Get(plan.getPath(), reqMods...)
+			if err == nil {
+				break
+			}
+			if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
+			return
+		}
+
+		// Check if exactly one object is returned
+		val = resId.Get("items").Array()
+		if len(val) == 0 {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if len(val) != 1 {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
+			return
+		}
+		break
 	}
 
 	// Extract ID from the object
@@ -197,7 +219,17 @@ func (r *VPNRALoadBalancingResource) Create(ctx context.Context, req resource.Cr
 
 	// Create object
 	body := plan.toBody(ctx, VPNRALoadBalancing{})
-	res, err := r.client.Put(plan.getPath()+"/"+url.PathEscape(plan.Id.ValueString()), body, reqMods...)
+	urlPath := plan.getPath() + "/" + url.PathEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (POST/PUT), got error: %s, %s", err, res.String()))
 		return
@@ -212,10 +244,6 @@ func (r *VPNRALoadBalancingResource) Create(ctx context.Context, req resource.Cr
 
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
-
-// End of section. //template:end create
-
-// Section below is generated&owned by "gen/generator.go". //template:begin read
 
 func (r *VPNRALoadBalancingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state VPNRALoadBalancing
@@ -235,7 +263,20 @@ func (r *VPNRALoadBalancingResource) Read(ctx context.Context, req resource.Read
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", state.Id.String()))
 
 	urlPath := state.getPath() + "/" + url.QueryEscape(state.Id.ValueString())
-	res, err := r.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = r.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 
 	if err != nil && strings.Contains(err.Error(), "StatusCode 404") {
 		resp.State.RemoveResource(ctx)
@@ -265,10 +306,6 @@ func (r *VPNRALoadBalancingResource) Read(ctx context.Context, req resource.Read
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
 
-// End of section. //template:end read
-
-// Section below is generated&owned by "gen/generator.go". //template:begin update
-
 func (r *VPNRALoadBalancingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state VPNRALoadBalancing
 
@@ -293,7 +330,20 @@ func (r *VPNRALoadBalancingResource) Update(ctx context.Context, req resource.Up
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Update", plan.Id.ValueString()))
 
 	body := plan.toBody(ctx, state)
-	res, err := r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString()), body, reqMods...)
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	urlPath := plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
 		return
@@ -304,8 +354,6 @@ func (r *VPNRALoadBalancingResource) Update(ctx context.Context, req resource.Up
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end update
 
 // Section below is generated&owned by "gen/generator.go". //template:begin delete
 
@@ -358,15 +406,3 @@ func (r *VPNRALoadBalancingResource) ImportState(ctx context.Context, req resour
 }
 
 // End of section. //template:end import
-
-// Section below is generated&owned by "gen/generator.go". //template:begin createSubresources
-
-// End of section. //template:end createSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin deleteSubresources
-
-// End of section. //template:end deleteSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
-
-// End of section. //template:end updateSubresources

--- a/internal/provider/resource_fmc_vpn_ra_secure_client_customization.go
+++ b/internal/provider/resource_fmc_vpn_ra_secure_client_customization.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/CiscoDevNet/terraform-provider-fmc/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -33,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-fmc"
+	"github.com/tidwall/gjson"
 )
 
 // End of section. //template:end imports
@@ -177,8 +179,6 @@ func (r *VPNRASecureClientCustomizationResource) Configure(_ context.Context, re
 
 // End of section. //template:end model
 
-// Section below is generated&owned by "gen/generator.go". //template:begin create
-
 func (r *VPNRASecureClientCustomizationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan VPNRASecureClientCustomization
 
@@ -195,17 +195,39 @@ func (r *VPNRASecureClientCustomizationResource) Create(ctx context.Context, req
 	}
 	//// ID needs to be retrieved from FMC, however we are expecting exactly one object
 	// Get objects from FMC
-	resId, err := r.client.Get(plan.getPath(), reqMods...)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
-		return
-	}
 
-	// Check if exactly one object is returned
-	val := resId.Get("items").Array()
-	if len(val) != 1 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
-		return
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var resId, res fmc.Res
+	var err error
+	var val []gjson.Result
+	for range 5 {
+		for range 5 {
+			resId, err = r.client.Get(plan.getPath(), reqMods...)
+			if err == nil {
+				break
+			}
+			if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object, got error: %s", err))
+			return
+		}
+
+		// Check if exactly one object is returned
+		val = resId.Get("items").Array()
+		if len(val) == 0 {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if len(val) != 1 {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Expected 1 object, got %d", len(val)))
+			return
+		}
+		break
 	}
 
 	// Extract ID from the object
@@ -220,7 +242,17 @@ func (r *VPNRASecureClientCustomizationResource) Create(ctx context.Context, req
 
 	// Create object
 	body := plan.toBody(ctx, VPNRASecureClientCustomization{})
-	res, err := r.client.Put(plan.getPath()+"/"+url.PathEscape(plan.Id.ValueString()), body, reqMods...)
+	urlPath := plan.getPath() + "/" + url.PathEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (POST/PUT), got error: %s, %s", err, res.String()))
 		return
@@ -235,10 +267,6 @@ func (r *VPNRASecureClientCustomizationResource) Create(ctx context.Context, req
 
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
-
-// End of section. //template:end create
-
-// Section below is generated&owned by "gen/generator.go". //template:begin read
 
 func (r *VPNRASecureClientCustomizationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state VPNRASecureClientCustomization
@@ -258,7 +286,20 @@ func (r *VPNRASecureClientCustomizationResource) Read(ctx context.Context, req r
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Read", state.Id.String()))
 
 	urlPath := state.getPath() + "/" + url.QueryEscape(state.Id.ValueString())
-	res, err := r.client.Get(urlPath, reqMods...)
+
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	for range 5 {
+		res, err = r.client.Get(urlPath, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 
 	if err != nil && strings.Contains(err.Error(), "StatusCode 404") {
 		resp.State.RemoveResource(ctx)
@@ -288,10 +329,6 @@ func (r *VPNRASecureClientCustomizationResource) Read(ctx context.Context, req r
 	helpers.SetFlagImporting(ctx, false, resp.Private, &resp.Diagnostics)
 }
 
-// End of section. //template:end read
-
-// Section below is generated&owned by "gen/generator.go". //template:begin update
-
 func (r *VPNRASecureClientCustomizationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state VPNRASecureClientCustomization
 
@@ -316,7 +353,20 @@ func (r *VPNRASecureClientCustomizationResource) Update(ctx context.Context, req
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Update", plan.Id.ValueString()))
 
 	body := plan.toBody(ctx, state)
-	res, err := r.client.Put(plan.getPath()+"/"+url.QueryEscape(plan.Id.ValueString()), body, reqMods...)
+	// FMCBUG CSCwq61583 FMC API: RAVPN sub-endpoints are unstable
+	var res fmc.Res
+	var err error
+	urlPath := plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString())
+	for range 5 {
+		res, err = r.client.Put(urlPath, body, reqMods...)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "StatusCode 404") && !strings.Contains(err.Error(), "StatusCode 400") {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
 		return
@@ -327,8 +377,6 @@ func (r *VPNRASecureClientCustomizationResource) Update(ctx context.Context, req
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
-
-// End of section. //template:end update
 
 // Section below is generated&owned by "gen/generator.go". //template:begin delete
 
@@ -381,15 +429,3 @@ func (r *VPNRASecureClientCustomizationResource) ImportState(ctx context.Context
 }
 
 // End of section. //template:end import
-
-// Section below is generated&owned by "gen/generator.go". //template:begin createSubresources
-
-// End of section. //template:end createSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin deleteSubresources
-
-// End of section. //template:end deleteSubresources
-
-// Section below is generated&owned by "gen/generator.go". //template:begin updateSubresources
-
-// End of section. //template:end updateSubresources

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -11,6 +11,7 @@ description: |-
 
 - (Fix) Prefilter policy is not assigned to Access Control Policy on creation
 - (Fix) `fmc_policy_assignment` for Health Policies on FMC 7.6 and later does not work correctly
+- (Fix) Attempt to stabilize VPN Remote Access resources
 - (Change) Remove `ValidateConfig` for `fmc_vpn_ra_connection_profiles`
 - (Change) Remove `fmc_device_ha_pair_physical_interface_mac_address` resource and data source
 - (Change) `fmc_file_analysis`: `store_files` attribute allowed values update


### PR DESCRIPTION
Remote Access VPN sub-enpoints tend to be unstable (do not return configured values, even if those are present). Implemented a workaround, so that multiple attempts are made, before the endpoint is marked as not-configured.