### PR TITLE
Add write_only & sensitive attributes to keychain and ospf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
-- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value
+- (Fix) `fmc_device_ospf` and `fmc_device_ospf_interface`: Sensitive attirbutes are now write-only, as API may not return their true value
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
+- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value
+
 ## 2.2.0
 
 - (Enhancement) Access Rule and Category: Add possibility to create at specific location

--- a/docs/data-sources/key_chain.md
+++ b/docs/data-sources/key_chain.md
@@ -42,7 +42,7 @@ Read-Only:
 - `accept_lifetime_end_type` (String) Type of end time for key acceptance lifetime.
 - `accept_lifetime_start` (String) Start time for key acceptance lifetime in YYYY-MM-DDTHH:mm:ss format.
 - `id` (Number) Key ID.
-- `key` (String) Crypto key string.
+- `key` (String, Sensitive) Crypto key string.
 - `send_lifetime_end` (String) End time for key send lifetime in YYYY-MM-DDTHH:mm:ss format (`DATETIME`) or duration in seconds (`DURATION`).
 - `send_lifetime_end_type` (String) Type of end time for key send lifetime.
 - `send_lifetime_start` (String) Start time for key send lifetime in YYYY-MM-DDTHH:mm:ss format.

--- a/docs/data-sources/key_chains.md
+++ b/docs/data-sources/key_chains.md
@@ -52,7 +52,7 @@ Read-Only:
 - `accept_lifetime_end_type` (String) Type of end time for key acceptance lifetime.
 - `accept_lifetime_start` (String) Start time for key acceptance lifetime in YYYY-MM-DDTHH:mm:ss format.
 - `id` (Number) Key ID.
-- `key` (String) Crypto key string.
+- `key` (String, Sensitive) Crypto key string.
 - `send_lifetime_end` (String) End time for key send lifetime in YYYY-MM-DDTHH:mm:ss format (`DATETIME`) or duration in seconds (`DURATION`).
 - `send_lifetime_end_type` (String) Type of end time for key send lifetime.
 - `send_lifetime_start` (String) Start time for key send lifetime in YYYY-MM-DDTHH:mm:ss format.

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,7 +10,7 @@ description: |-
 ## Unreleased
 
 - (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
-- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value
+- (Fix) `fmc_device_ospf` and `fmc_device_ospf_interface`: Sensitive attirbutes are now write-only, as API may not return their true value
 
 ## 2.2.0
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,11 @@ description: |-
 
 # Changelog
 
+## Unreleased
+
+- (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
+- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value
+
 ## 2.2.0
 
 - (Enhancement) Access Rule and Category: Add possibility to create at specific location

--- a/docs/resources/key_chain.md
+++ b/docs/resources/key_chain.md
@@ -56,7 +56,7 @@ Required:
 
 - `id` (Number) Key ID.
   - Range: `0`-`255`
-- `key` (String) Crypto key string.
+- `key` (String, Sensitive) Crypto key string.
 
 Optional:
 

--- a/docs/resources/key_chains.md
+++ b/docs/resources/key_chains.md
@@ -78,7 +78,7 @@ Required:
 
 - `id` (Number) Key ID.
   - Range: `0`-`255`
-- `key` (String) Crypto key string.
+- `key` (String, Sensitive) Crypto key string.
 
 Optional:
 

--- a/gen/definitions/device_ospf.yaml
+++ b/gen/definitions/device_ospf.yaml
@@ -320,6 +320,7 @@ attributes:
             string_max_length: 8
             sensitive: true
             description: Password for authentication.
+            write_only: true
           - model_name: authKey
             data_path: [authentication, areaAuth, passwdAuth]
             tf_name: authentication_area_password
@@ -327,6 +328,7 @@ attributes:
             sensitive: true
             string_max_length: 8
             description: Password for area authentication.
+            write_only: true
           - model_name: md5AuthList
             data_path: [authentication, areaAuth]
             tf_name: authentication_area_md5s
@@ -345,6 +347,7 @@ attributes:
                 sensitive: true
                 description: MD5 authentication key.
                 mandatory: true
+                write_only: true
           - model_name: md5AuthList
             data_path: [authentication]
             tf_name: authentication_md5s
@@ -363,6 +366,7 @@ attributes:
                 sensitive: true
                 description: MD5 authentication key.
                 mandatory: true
+                write_only: true
           - model_name: id
             data_path: [authentication, keyChain, authKey]
             tf_name: authentication_key_chain_id

--- a/gen/definitions/device_ospf_interface.yaml
+++ b/gen/definitions/device_ospf_interface.yaml
@@ -119,6 +119,7 @@ attributes:
     type: String
     string_max_length: 8
     sensitive: true
+    write_only: true
     description: Password for authentication.
     exclude_example: true
     exclude_test: true
@@ -127,6 +128,7 @@ attributes:
     tf_name: authentication_area_password
     type: String
     sensitive: true
+    write_only: true
     string_max_length: 8
     description: Password for area authentication.
     exclude_example: true
@@ -149,6 +151,7 @@ attributes:
         tf_name: key
         type: String
         sensitive: true
+        write_only: true
         description: MD5 authentication key.
         mandatory: true
   - model_name: md5AuthList
@@ -169,6 +172,7 @@ attributes:
         tf_name: key
         type: String
         sensitive: true
+        write_only: true
         description: MD5 authentication key.
         mandatory: true
   - model_name: id

--- a/gen/definitions/key_chain.yaml
+++ b/gen/definitions/key_chain.yaml
@@ -42,6 +42,8 @@ attributes:
         type: String
         example: my_secret_key
         mandatory: true
+        sensivite: true
+        write_only: true
       - model_name: cryptoEncryptionType
         data_path: [authString]
         type: String

--- a/gen/definitions/key_chain.yaml
+++ b/gen/definitions/key_chain.yaml
@@ -42,7 +42,7 @@ attributes:
         type: String
         example: my_secret_key
         mandatory: true
-        sensivite: true
+        sensitive: true
         write_only: true
       - model_name: cryptoEncryptionType
         data_path: [authString]

--- a/gen/definitions/key_chains.yaml
+++ b/gen/definitions/key_chains.yaml
@@ -52,7 +52,7 @@ attributes:
             example: my_secret_key
             mandatory: true
             write_only: true
-            sensivite: true
+            sensitive: true
           - model_name: cryptoEncryptionType
             data_path: [authString]
             type: String

--- a/gen/definitions/key_chains.yaml
+++ b/gen/definitions/key_chains.yaml
@@ -51,6 +51,8 @@ attributes:
             type: String
             example: my_secret_key
             mandatory: true
+            write_only: true
+            sensivite: true
           - model_name: cryptoEncryptionType
             data_path: [authString]
             type: String

--- a/internal/provider/data_source_fmc_key_chain.go
+++ b/internal/provider/data_source_fmc_key_chain.go
@@ -96,6 +96,7 @@ func (d *KeyChainDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 						"key": schema.StringAttribute{
 							MarkdownDescription: "Crypto key string.",
 							Computed:            true,
+							Sensitive:           true,
 						},
 						"accept_lifetime_start": schema.StringAttribute{
 							MarkdownDescription: "Start time for key acceptance lifetime in YYYY-MM-DDTHH:mm:ss format.",

--- a/internal/provider/data_source_fmc_key_chain_test.go
+++ b/internal/provider/data_source_fmc_key_chain_test.go
@@ -34,7 +34,6 @@ func TestAccDataSourceFmcKeyChain(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_key_chain.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chain.test", "description", "My Host object"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chain.test", "keys.0.id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chain.test", "keys.0.key", "my_secret_key"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chain.test", "keys.0.accept_lifetime_start", "2025-08-25T12:14:23"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chain.test", "keys.0.accept_lifetime_end_type", "DATETIME"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chain.test", "keys.0.accept_lifetime_end", "2026-08-25T12:14:23"))

--- a/internal/provider/data_source_fmc_key_chains.go
+++ b/internal/provider/data_source_fmc_key_chains.go
@@ -96,6 +96,7 @@ func (d *KeyChainsDataSource) Schema(ctx context.Context, req datasource.SchemaR
 									"key": schema.StringAttribute{
 										MarkdownDescription: "Crypto key string.",
 										Computed:            true,
+										Sensitive:           true,
 									},
 									"accept_lifetime_start": schema.StringAttribute{
 										MarkdownDescription: "Start time for key acceptance lifetime in YYYY-MM-DDTHH:mm:ss format.",

--- a/internal/provider/data_source_fmc_key_chains_test.go
+++ b/internal/provider/data_source_fmc_key_chains_test.go
@@ -34,7 +34,6 @@ func TestAccDataSourceFmcKeyChains(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttrSet("data.fmc_key_chains.test", "items.my_key_chains.type"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.fmc_key_chains.test", "items.my_key_chains.description", "My Host object"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.key", "my_secret_key"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.accept_lifetime_start", "2025-08-25T12:14:23"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.accept_lifetime_end_type", "DATETIME"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.accept_lifetime_end", "2026-08-25T12:14:23"))

--- a/internal/provider/model_fmc_device_ospf.go
+++ b/internal/provider/model_fmc_device_ospf.go
@@ -695,16 +695,6 @@ func (data *DeviceOSPF) fromBody(ctx context.Context, res gjson.Result) {
 					} else {
 						data.DeadInterval = types.Int64Value(40)
 					}
-					if value := res.Get("authentication.passwdAuth.authKey"); value.Exists() {
-						data.AuthenticationPassword = types.StringValue(value.String())
-					} else {
-						data.AuthenticationPassword = types.StringNull()
-					}
-					if value := res.Get("authentication.areaAuth.passwdAuth.authKey"); value.Exists() {
-						data.AuthenticationAreaPassword = types.StringValue(value.String())
-					} else {
-						data.AuthenticationAreaPassword = types.StringNull()
-					}
 					if value := res.Get("authentication.areaAuth.md5AuthList"); value.Exists() {
 						data.AuthenticationAreaMd5s = make([]DeviceOSPFAreasVirtualLinksAuthenticationAreaMd5s, 0)
 						value.ForEach(func(k, res gjson.Result) bool {
@@ -714,11 +704,6 @@ func (data *DeviceOSPF) fromBody(ctx context.Context, res gjson.Result) {
 								data.Id = types.Int64Value(value.Int())
 							} else {
 								data.Id = types.Int64Null()
-							}
-							if value := res.Get("md5Key"); value.Exists() {
-								data.Key = types.StringValue(value.String())
-							} else {
-								data.Key = types.StringNull()
 							}
 							(*parent).AuthenticationAreaMd5s = append((*parent).AuthenticationAreaMd5s, data)
 							return true
@@ -733,11 +718,6 @@ func (data *DeviceOSPF) fromBody(ctx context.Context, res gjson.Result) {
 								data.Id = types.Int64Value(value.Int())
 							} else {
 								data.Id = types.Int64Null()
-							}
-							if value := res.Get("md5Key"); value.Exists() {
-								data.Key = types.StringValue(value.String())
-							} else {
-								data.Key = types.StringNull()
 							}
 							(*parent).AuthenticationMd5s = append((*parent).AuthenticationMd5s, data)
 							return true
@@ -1284,16 +1264,6 @@ func (data *DeviceOSPF) fromBodyPartial(ctx context.Context, res gjson.Result) {
 			} else if data.DeadInterval.ValueInt64() != 40 {
 				data.DeadInterval = types.Int64Null()
 			}
-			if value := res.Get("authentication.passwdAuth.authKey"); value.Exists() && !data.AuthenticationPassword.IsNull() {
-				data.AuthenticationPassword = types.StringValue(value.String())
-			} else {
-				data.AuthenticationPassword = types.StringNull()
-			}
-			if value := res.Get("authentication.areaAuth.passwdAuth.authKey"); value.Exists() && !data.AuthenticationAreaPassword.IsNull() {
-				data.AuthenticationAreaPassword = types.StringValue(value.String())
-			} else {
-				data.AuthenticationAreaPassword = types.StringNull()
-			}
 			for i := 0; i < len(data.AuthenticationAreaMd5s); i++ {
 				keys := [...]string{"md5KeyId"}
 				keyValues := [...]string{strconv.FormatInt(data.AuthenticationAreaMd5s[i].Id.ValueInt64(), 10)}
@@ -1334,11 +1304,6 @@ func (data *DeviceOSPF) fromBodyPartial(ctx context.Context, res gjson.Result) {
 					data.Id = types.Int64Value(value.Int())
 				} else {
 					data.Id = types.Int64Null()
-				}
-				if value := res.Get("md5Key"); value.Exists() && !data.Key.IsNull() {
-					data.Key = types.StringValue(value.String())
-				} else {
-					data.Key = types.StringNull()
 				}
 				(*parent).AuthenticationAreaMd5s[i] = data
 			}
@@ -1382,11 +1347,6 @@ func (data *DeviceOSPF) fromBodyPartial(ctx context.Context, res gjson.Result) {
 					data.Id = types.Int64Value(value.Int())
 				} else {
 					data.Id = types.Int64Null()
-				}
-				if value := res.Get("md5Key"); value.Exists() && !data.Key.IsNull() {
-					data.Key = types.StringValue(value.String())
-				} else {
-					data.Key = types.StringNull()
 				}
 				(*parent).AuthenticationMd5s[i] = data
 			}

--- a/internal/provider/model_fmc_device_ospf_interface.go
+++ b/internal/provider/model_fmc_device_ospf_interface.go
@@ -232,16 +232,6 @@ func (data *DeviceOSPFInterface) fromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.Bfd = types.BoolNull()
 	}
-	if value := res.Get("ospfProtocolConfiguration.ospfAuthentication.passwdAuth.authKey"); value.Exists() {
-		data.AuthenticationPassword = types.StringValue(value.String())
-	} else {
-		data.AuthenticationPassword = types.StringNull()
-	}
-	if value := res.Get("ospfProtocolConfiguration.ospfAuthentication.areaAuth.passwdAuth.authKey"); value.Exists() {
-		data.AuthenticationAreaPassword = types.StringValue(value.String())
-	} else {
-		data.AuthenticationAreaPassword = types.StringNull()
-	}
 	if value := res.Get("ospfProtocolConfiguration.ospfAuthentication.areaAuth.md5AuthList"); value.Exists() {
 		data.AuthenticationAreaMd5s = make([]DeviceOSPFInterfaceAuthenticationAreaMd5s, 0)
 		value.ForEach(func(k, res gjson.Result) bool {
@@ -251,11 +241,6 @@ func (data *DeviceOSPFInterface) fromBody(ctx context.Context, res gjson.Result)
 				data.Id = types.Int64Value(value.Int())
 			} else {
 				data.Id = types.Int64Null()
-			}
-			if value := res.Get("md5Key"); value.Exists() {
-				data.Key = types.StringValue(value.String())
-			} else {
-				data.Key = types.StringNull()
 			}
 			(*parent).AuthenticationAreaMd5s = append((*parent).AuthenticationAreaMd5s, data)
 			return true
@@ -270,11 +255,6 @@ func (data *DeviceOSPFInterface) fromBody(ctx context.Context, res gjson.Result)
 				data.Id = types.Int64Value(value.Int())
 			} else {
 				data.Id = types.Int64Null()
-			}
-			if value := res.Get("md5Key"); value.Exists() {
-				data.Key = types.StringValue(value.String())
-			} else {
-				data.Key = types.StringNull()
 			}
 			(*parent).AuthenticationMd5s = append((*parent).AuthenticationMd5s, data)
 			return true
@@ -356,16 +336,6 @@ func (data *DeviceOSPFInterface) fromBodyPartial(ctx context.Context, res gjson.
 	} else {
 		data.Bfd = types.BoolNull()
 	}
-	if value := res.Get("ospfProtocolConfiguration.ospfAuthentication.passwdAuth.authKey"); value.Exists() && !data.AuthenticationPassword.IsNull() {
-		data.AuthenticationPassword = types.StringValue(value.String())
-	} else {
-		data.AuthenticationPassword = types.StringNull()
-	}
-	if value := res.Get("ospfProtocolConfiguration.ospfAuthentication.areaAuth.passwdAuth.authKey"); value.Exists() && !data.AuthenticationAreaPassword.IsNull() {
-		data.AuthenticationAreaPassword = types.StringValue(value.String())
-	} else {
-		data.AuthenticationAreaPassword = types.StringNull()
-	}
 	for i := 0; i < len(data.AuthenticationAreaMd5s); i++ {
 		keys := [...]string{"md5KeyId"}
 		keyValues := [...]string{strconv.FormatInt(data.AuthenticationAreaMd5s[i].Id.ValueInt64(), 10)}
@@ -406,11 +376,6 @@ func (data *DeviceOSPFInterface) fromBodyPartial(ctx context.Context, res gjson.
 			data.Id = types.Int64Value(value.Int())
 		} else {
 			data.Id = types.Int64Null()
-		}
-		if value := res.Get("md5Key"); value.Exists() && !data.Key.IsNull() {
-			data.Key = types.StringValue(value.String())
-		} else {
-			data.Key = types.StringNull()
 		}
 		(*parent).AuthenticationAreaMd5s[i] = data
 	}
@@ -454,11 +419,6 @@ func (data *DeviceOSPFInterface) fromBodyPartial(ctx context.Context, res gjson.
 			data.Id = types.Int64Value(value.Int())
 		} else {
 			data.Id = types.Int64Null()
-		}
-		if value := res.Get("md5Key"); value.Exists() && !data.Key.IsNull() {
-			data.Key = types.StringValue(value.String())
-		} else {
-			data.Key = types.StringNull()
 		}
 		(*parent).AuthenticationMd5s[i] = data
 	}

--- a/internal/provider/model_fmc_key_chain.go
+++ b/internal/provider/model_fmc_key_chain.go
@@ -148,11 +148,6 @@ func (data *KeyChain) fromBody(ctx context.Context, res gjson.Result) {
 			} else {
 				data.Id = types.Int64Null()
 			}
-			if value := res.Get("authString.cryptoKeyString"); value.Exists() {
-				data.Key = types.StringValue(value.String())
-			} else {
-				data.Key = types.StringNull()
-			}
 			if value := res.Get("acceptLifeTime.startLifeTimeValue"); value.Exists() {
 				data.AcceptLifetimeStart = types.StringValue(value.String())
 			} else {
@@ -257,11 +252,6 @@ func (data *KeyChain) fromBodyPartial(ctx context.Context, res gjson.Result) {
 			data.Id = types.Int64Value(value.Int())
 		} else {
 			data.Id = types.Int64Null()
-		}
-		if value := res.Get("authString.cryptoKeyString"); value.Exists() && !data.Key.IsNull() {
-			data.Key = types.StringValue(value.String())
-		} else {
-			data.Key = types.StringNull()
 		}
 		if value := res.Get("acceptLifeTime.startLifeTimeValue"); value.Exists() && !data.AcceptLifetimeStart.IsNull() {
 			data.AcceptLifetimeStart = types.StringValue(value.String())

--- a/internal/provider/model_fmc_key_chains.go
+++ b/internal/provider/model_fmc_key_chains.go
@@ -179,11 +179,6 @@ func (data *KeyChains) fromBody(ctx context.Context, res gjson.Result) {
 				} else {
 					data.Id = types.Int64Null()
 				}
-				if value := res.Get("authString.cryptoKeyString"); value.Exists() {
-					data.Key = types.StringValue(value.String())
-				} else {
-					data.Key = types.StringNull()
-				}
 				if value := res.Get("acceptLifeTime.startLifeTimeValue"); value.Exists() {
 					data.AcceptLifetimeStart = types.StringValue(value.String())
 				} else {
@@ -305,11 +300,6 @@ func (data *KeyChains) fromBodyPartial(ctx context.Context, res gjson.Result) {
 				data.Id = types.Int64Value(value.Int())
 			} else {
 				data.Id = types.Int64Null()
-			}
-			if value := res.Get("authString.cryptoKeyString"); value.Exists() && !data.Key.IsNull() {
-				data.Key = types.StringValue(value.String())
-			} else {
-				data.Key = types.StringNull()
 			}
 			if value := res.Get("acceptLifeTime.startLifeTimeValue"); value.Exists() && !data.AcceptLifetimeStart.IsNull() {
 				data.AcceptLifetimeStart = types.StringValue(value.String())

--- a/internal/provider/resource_fmc_key_chain.go
+++ b/internal/provider/resource_fmc_key_chain.go
@@ -111,6 +111,7 @@ func (r *KeyChainResource) Schema(ctx context.Context, req resource.SchemaReques
 						"key": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Crypto key string.").String,
 							Required:            true,
+							Sensitive:           true,
 						},
 						"accept_lifetime_start": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("Start time for key acceptance lifetime in YYYY-MM-DDTHH:mm:ss format.").String,

--- a/internal/provider/resource_fmc_key_chain_test.go
+++ b/internal/provider/resource_fmc_key_chain_test.go
@@ -35,7 +35,6 @@ func TestAccFmcKeyChain(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_key_chain.test", "type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chain.test", "description", "My Host object"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chain.test", "keys.0.id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chain.test", "keys.0.key", "my_secret_key"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chain.test", "keys.0.accept_lifetime_start", "2025-08-25T12:14:23"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chain.test", "keys.0.accept_lifetime_end_type", "DATETIME"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chain.test", "keys.0.accept_lifetime_end", "2026-08-25T12:14:23"))

--- a/internal/provider/resource_fmc_key_chains.go
+++ b/internal/provider/resource_fmc_key_chains.go
@@ -122,6 +122,7 @@ func (r *KeyChainsResource) Schema(ctx context.Context, req resource.SchemaReque
 									"key": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Crypto key string.").String,
 										Required:            true,
+										Sensitive:           true,
 									},
 									"accept_lifetime_start": schema.StringAttribute{
 										MarkdownDescription: helpers.NewAttributeDescription("Start time for key acceptance lifetime in YYYY-MM-DDTHH:mm:ss format.").String,

--- a/internal/provider/resource_fmc_key_chains_test.go
+++ b/internal/provider/resource_fmc_key_chains_test.go
@@ -35,7 +35,6 @@ func TestAccFmcKeyChains(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttrSet("fmc_key_chains.test", "items.my_key_chains.type"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.description", "My Host object"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.key", "my_secret_key"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.accept_lifetime_start", "2025-08-25T12:14:23"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.accept_lifetime_end_type", "DATETIME"))
 	checks = append(checks, resource.TestCheckResourceAttr("fmc_key_chains.test", "items.my_key_chains.keys.0.accept_lifetime_end", "2026-08-25T12:14:23"))

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,7 +10,7 @@ description: |-
 ## Unreleased
 
 - (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
-- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value
+- (Fix) `fmc_device_ospf` and `fmc_device_ospf_interface`: Sensitive attirbutes are now write-only, as API may not return their true value
 
 ## 2.2.0
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,11 @@ description: |-
 
 # Changelog
 
+## Unreleased
+
+- (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
+- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value
+
 ## 2.2.0
 
 - (Enhancement) Access Rule and Category: Add possibility to create at specific location


### PR DESCRIPTION
- (Fix) `fmc_key_chain`: `key` attribute is now sensitive and write only, as API may not return its true value
- (Fix) `fmc_device_ospf`: Sensitive attirbutes are now write-only, as API may not return their true value