### PR TITLE
`fmc_device`: Add domain reference for the policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - (Enhancement) Performance improvements
+- (Enhancement) `fmc_device`: Add `access_control_policy_domain`, `nat_policy_domain` and `health_policy_domain` to support policies that exist in a different domain than the device
 - (Enhancement) `fmc_device_physical_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_etherchannel_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_subinterface`: Increase the maximum MTU from `9000` to `9198`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - (Enhancement) `fmc_device_physical_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_etherchannel_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_subinterface`: Increase the maximum MTU from `9000` to `9198`
+- (Fix) `fmc_device`: Fix wrong assignment of `health_policy_id` in HA Pair and Cluster configurations
 
 ## 2.5.0
 

--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -29,6 +29,7 @@ data "fmc_device" "example" {
 
 ### Read-Only
 
+- `access_control_policy_domain` (String) Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.
 - `access_control_policy_id` (String) Id of the assigned Access Control Policy.
 - `container_id` (String) Id of the parent container. Empty if device is Standalone.
 - `container_name` (String) Name of the parent container. Empty if device is Standalone.
@@ -36,12 +37,14 @@ data "fmc_device" "example" {
 - `container_status` (String) Status of the device in DeviceHAPair (Active, Standby, but other possible as well).
 - `container_type` (String) Type of the parent container (DeviceHAPair or DeviceCluster). Empty if device is Standalone.
 - `device_group_id` (String) Id of the device group.
+- `health_policy_domain` (String) Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.
 - `health_policy_id` (String) Id of the assigned Health policy. Every device requires health policy assignment, hence removal of this attribute does not trigger health policy de-assignment.
 - `host` (String) Hostname or IP address of the device. Either the `host` or `nat_id` must be present.
 - `is_multi_instance` (Boolean) True if the device is part of a multi-instance.
 - `is_part_of_container` (Boolean) True if the device is part of a container (DeviceHAPair or DeviceCluster).
 - `licenses` (Set of String) Array of strings representing the license capabilities on the managed device.
 - `nat_id` (String) (used for device registration behind NAT) If the device to be registered and the Firepower Management Center are separated by network address translation (NAT), set a unique string identifier.
+- `nat_policy_domain` (String) Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.
 - `nat_policy_id` (String) Id of the assigned FTD NAT policy.
 - `object_group_search` (Boolean) Enables Object Group Search
 - `performance_tier` (String) Performance tier for the managed device.

--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -29,7 +29,7 @@ data "fmc_device" "example" {
 
 ### Read-Only
 
-- `access_control_policy_domain` (String) Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.
+- `access_control_policy_domain` (String) Not populated by this data source; Device's domain is assumed implicitly.
 - `access_control_policy_id` (String) Id of the assigned Access Control Policy.
 - `container_id` (String) Id of the parent container. Empty if device is Standalone.
 - `container_name` (String) Name of the parent container. Empty if device is Standalone.
@@ -37,15 +37,15 @@ data "fmc_device" "example" {
 - `container_status` (String) Status of the device in DeviceHAPair (Active, Standby, but other possible as well).
 - `container_type` (String) Type of the parent container (DeviceHAPair or DeviceCluster). Empty if device is Standalone.
 - `device_group_id` (String) Id of the device group.
-- `health_policy_domain` (String) Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.
+- `health_policy_domain` (String) Not populated by this data source; Device's domain is assumed implicitly.
 - `health_policy_id` (String) Id of the assigned Health policy. Every device requires health policy assignment, hence removal of this attribute does not trigger health policy de-assignment.
 - `host` (String) Hostname or IP address of the device. Either the `host` or `nat_id` must be present.
 - `is_multi_instance` (Boolean) True if the device is part of a multi-instance.
 - `is_part_of_container` (Boolean) True if the device is part of a container (DeviceHAPair or DeviceCluster).
 - `licenses` (Set of String) Array of strings representing the license capabilities on the managed device.
 - `nat_id` (String) (used for device registration behind NAT) If the device to be registered and the Firepower Management Center are separated by network address translation (NAT), set a unique string identifier.
-- `nat_policy_domain` (String) Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.
-- `nat_policy_id` (String) Id of the assigned FTD NAT policy.
+- `nat_policy_domain` (String) Not populated by this data source; Device's domain is assumed implicitly.
+- `nat_policy_id` (String) Id of the assigned FTD NAT policy. Only populated if the NAT policy resides in the same FMC domain as the device.
 - `object_group_search` (Boolean) Enables Object Group Search
 - `performance_tier` (String) Performance tier for the managed device.
 - `prohibit_packet_transfer` (Boolean) Value true prohibits the device from sending packet data with events to the Firepower Management Center. Value false allows the transfer when a certain event is triggered. Not all traffic data is sent; connection events do not include a payload, only connection metadata.

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,6 +10,7 @@ description: |-
 ## Unreleased
 
 - (Enhancement) Performance improvements
+- (Enhancement) `fmc_device`: Add `access_control_policy_domain`, `nat_policy_domain` and `health_policy_domain` to support policies that exist in a different domain than the device
 - (Enhancement) `fmc_device_physical_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_etherchannel_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_subinterface`: Increase the maximum MTU from `9000` to `9198`

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -14,6 +14,7 @@ description: |-
 - (Enhancement) `fmc_device_physical_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_etherchannel_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_subinterface`: Increase the maximum MTU from `9000` to `9198`
+- (Fix) `fmc_device`: Fix wrong assignment of `health_policy_id` in HA Pair and Cluster configurations
 
 ## 2.5.0
 

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -39,10 +39,13 @@ resource "fmc_device" "example" {
 
 ### Optional
 
+- `access_control_policy_domain` (String) Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.
 - `device_group_id` (String) Id of the device group.
 - `domain` (String) Name of the FMC domain
+- `health_policy_domain` (String) Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.
 - `health_policy_id` (String) Id of the assigned Health policy. Every device requires health policy assignment, hence removal of this attribute does not trigger health policy de-assignment.
 - `nat_id` (String) (used for device registration behind NAT) If the device to be registered and the Firepower Management Center are separated by network address translation (NAT), set a unique string identifier.
+- `nat_policy_domain` (String) Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.
 - `nat_policy_id` (String) Id of the assigned FTD NAT policy.
 - `object_group_search` (Boolean) Enables Object Group Search
 - `performance_tier` (String) Performance tier for the managed device.

--- a/gen/definitions/device.yaml
+++ b/gen/definitions/device.yaml
@@ -1,4 +1,4 @@
-# Manual resource - Create, Read, Update, Delete
+# Manual resource - Create, Read, Update, Delete, fromBodyPolicy, updatePolicy, resolvePolicyDomain, policyReqMods
 ---
 name: Device
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/devices/devicerecords
@@ -111,10 +111,24 @@ attributes:
     description: Id of the assigned Access Control Policy.
     example: 76d24097-41c4-4558-a4d0-a8c07ac08470
     test_value: fmc_access_control_policy.test.id
+  - tf_name: access_control_policy_domain
+    tf_only: true
+    type: String
+    description: >-
+      Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.
+    exclude_example: true
+    exclude_test: true
   - model_name: dummy_nat_policy_id
     tf_name: nat_policy_id
     type: String
     description: Id of the assigned FTD NAT policy.
+    exclude_example: true
+    test_value: fmc_ftd_nat_policy.test.id
+  - tf_name: nat_policy_domain
+    tf_only: true
+    type: String
+    description: >-
+      Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.
     exclude_example: true
     exclude_test: true
   - model_name: id
@@ -122,6 +136,13 @@ attributes:
     tf_name: health_policy_id
     type: String
     description: Id of the assigned Health policy. Every device requires health policy assignment, hence removal of this attribute does not trigger health policy de-assignment.
+    exclude_example: true
+    exclude_test: true
+  - tf_name: health_policy_domain
+    tf_only: true
+    type: String
+    description: >-
+      Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.
     exclude_example: true
     exclude_test: true
   # Container Details
@@ -181,4 +202,8 @@ test_prerequisites: |-
   resource "fmc_access_control_policy" "test" {
     name = "fmc_device_access_control_policy"
     default_action = "BLOCK"
+  }
+
+  resource "fmc_ftd_nat_policy" "test" {
+    name        = "fmc_device_nat_policy"
   }

--- a/gen/definitions/device.yaml
+++ b/gen/definitions/device.yaml
@@ -1,4 +1,4 @@
-# Manual resource - Create, Read, Update, Delete, fromBodyPolicy, updatePolicy, resolvePolicyDomain, policyReqMods
+# Manual resource - Create, Read, Update, Delete, fromBodyPolicy, updatePolicy, resolvePolicyDomain, policyReqMods, displayDomain, policyDomainPath
 ---
 name: Device
 rest_endpoint: /api/fmc_config/v1/domain/{DOMAIN_UUID}/devices/devicerecords
@@ -116,12 +116,17 @@ attributes:
     type: String
     description: >-
       Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.
+    ds_description: >-
+      Not populated by this data source; Device's domain is assumed implicitly.
     exclude_example: true
     exclude_test: true
   - model_name: dummy_nat_policy_id
     tf_name: nat_policy_id
     type: String
     description: Id of the assigned FTD NAT policy.
+    ds_description: >-
+      Id of the assigned FTD NAT policy. Only populated if the NAT policy resides in the same FMC domain as the
+      device.
     exclude_example: true
     test_value: fmc_ftd_nat_policy.test.id
   - tf_name: nat_policy_domain
@@ -129,6 +134,8 @@ attributes:
     type: String
     description: >-
       Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.
+    ds_description: >-
+      Not populated by this data source; Device's domain is assumed implicitly.
     exclude_example: true
     exclude_test: true
   - model_name: id
@@ -143,6 +150,8 @@ attributes:
     type: String
     description: >-
       Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.
+    ds_description: >-
+      Not populated by this data source; Device's domain is assumed implicitly.
     exclude_example: true
     exclude_test: true
   # Container Details

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -145,6 +145,7 @@ type YamlConfigAttribute struct {
 	ExcludeTest                         bool                  `yaml:"exclude_test"`
 	ExcludeExample                      bool                  `yaml:"exclude_example"`
 	Description                         string                `yaml:"description"`
+	DsDescription                       string                `yaml:"ds_description"`
 	Example                             string                `yaml:"example"`
 	EnumValues                          []string              `yaml:"enum_values"`
 	MinList                             int64                 `yaml:"min_list"`

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -47,6 +47,7 @@ attribute:
   exclude_test: bool(required=False) # Exclude attribute from acceptance test only (example/documentation is still generated)
   exclude_example: bool(required=False) # Exclude attribute from example (documentation)
   description: str(required=False) # Attribute description
+  ds_description: str(required=False) # Attribute description override used only in the data source schema. Falls back to `description` if not set
   example: any(str(), int(), bool(), required=False) # Example value for documentation, also used for acceptance test
   enum_values: list(str(), required=False) # List of enum values, only relevant if type is "String". Null value is instead governed by `mandatory`, never include null here
   min_list: int(required=False) # Minimum number of elements in a list, only relevant if type is "List"

--- a/gen/templates/data_source.go
+++ b/gen/templates/data_source.go
@@ -100,7 +100,7 @@ func (d *{{camelCase .Name}}DataSource) Schema(ctx context.Context, req datasour
 			{{- range .Attributes}}
 			{{- if not .Value}}
 			"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
-				MarkdownDescription: "{{.Description}}",
+				MarkdownDescription: "{{if .DsDescription}}{{.DsDescription}}{{else}}{{.Description}}{{end}}",
 				{{- if isListSet .}}
 				ElementType:         types.{{.ElementType}}Type,
 				{{- end}}
@@ -125,7 +125,7 @@ func (d *{{camelCase .Name}}DataSource) Schema(ctx context.Context, req datasour
 						{{- range .Attributes}}
 						{{- if not .Value}}
 						"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
-							MarkdownDescription: "{{.Description}}",
+							MarkdownDescription: "{{if .DsDescription}}{{.DsDescription}}{{else}}{{.Description}}{{end}}",
 							{{- if isListSet .}}
 							ElementType:         types.{{.ElementType}}Type,
 							{{- end}}
@@ -143,7 +143,7 @@ func (d *{{camelCase .Name}}DataSource) Schema(ctx context.Context, req datasour
 									{{- range .Attributes}}
 									{{- if not .Value}}
 									"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
-										MarkdownDescription: "{{.Description}}",
+										MarkdownDescription: "{{if .DsDescription}}{{.DsDescription}}{{else}}{{.Description}}{{end}}",
 										{{- if isListSet .}}
 										ElementType:         types.{{.ElementType}}Type,
 										{{- end}}
@@ -157,7 +157,7 @@ func (d *{{camelCase .Name}}DataSource) Schema(ctx context.Context, req datasour
 												{{- range .Attributes}}
 												{{- if not .Value}}
 												"{{.TfName}}": schema.{{if isNestedListMapSet .}}{{.Type}}Nested{{else if isList .}}List{{else if isSet .}}Set{{else if eq .Type "Versions"}}List{{else if eq .Type "Version"}}Int64{{else}}{{.Type}}{{end}}Attribute{
-													MarkdownDescription: "{{.Description}}",
+													MarkdownDescription: "{{if .DsDescription}}{{.DsDescription}}{{else}}{{.Description}}{{end}}",
 													{{- if isListSet .}}
 													ElementType:         types.{{.ElementType}}Type,
 													{{- end}}

--- a/internal/provider/data_source_fmc_device.go
+++ b/internal/provider/data_source_fmc_device.go
@@ -121,12 +121,24 @@ func (d *DeviceDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "Id of the assigned Access Control Policy.",
 				Computed:            true,
 			},
+			"access_control_policy_domain": schema.StringAttribute{
+				MarkdownDescription: "Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.",
+				Computed:            true,
+			},
 			"nat_policy_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the assigned FTD NAT policy.",
 				Computed:            true,
 			},
+			"nat_policy_domain": schema.StringAttribute{
+				MarkdownDescription: "Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.",
+				Computed:            true,
+			},
 			"health_policy_id": schema.StringAttribute{
 				MarkdownDescription: "Id of the assigned Health policy. Every device requires health policy assignment, hence removal of this attribute does not trigger health policy de-assignment.",
+				Computed:            true,
+			},
+			"health_policy_domain": schema.StringAttribute{
+				MarkdownDescription: "Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.",
 				Computed:            true,
 			},
 			"container_id": schema.StringAttribute{
@@ -241,7 +253,12 @@ func (d *DeviceDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	res = config.fromBodyPolicy(ctx, res, policies)
+	// Data source has no per-policy domain attributes, hence all policies are looked up in the domain of the device
+	res = config.fromBodyPolicy(ctx, res, map[string]gjson.Result{
+		"AccessPolicy": policies,
+		"FTDNatPolicy": policies,
+		"HealthPolicy": policies,
+	})
 	config.fromBody(ctx, res)
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Read finished successfully", config.Id.ValueString()))

--- a/internal/provider/data_source_fmc_device.go
+++ b/internal/provider/data_source_fmc_device.go
@@ -122,15 +122,15 @@ func (d *DeviceDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Computed:            true,
 			},
 			"access_control_policy_domain": schema.StringAttribute{
-				MarkdownDescription: "Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.",
+				MarkdownDescription: "Not populated by this data source; Device's domain is assumed implicitly.",
 				Computed:            true,
 			},
 			"nat_policy_id": schema.StringAttribute{
-				MarkdownDescription: "Id of the assigned FTD NAT policy.",
+				MarkdownDescription: "Id of the assigned FTD NAT policy. Only populated if the NAT policy resides in the same FMC domain as the device.",
 				Computed:            true,
 			},
 			"nat_policy_domain": schema.StringAttribute{
-				MarkdownDescription: "Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.",
+				MarkdownDescription: "Not populated by this data source; Device's domain is assumed implicitly.",
 				Computed:            true,
 			},
 			"health_policy_id": schema.StringAttribute{
@@ -138,7 +138,7 @@ func (d *DeviceDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Computed:            true,
 			},
 			"health_policy_domain": schema.StringAttribute{
-				MarkdownDescription: "Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.",
+				MarkdownDescription: "Not populated by this data source; Device's domain is assumed implicitly.",
 				Computed:            true,
 			},
 			"container_id": schema.StringAttribute{

--- a/internal/provider/model_fmc_device.go
+++ b/internal/provider/model_fmc_device.go
@@ -34,29 +34,32 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 
 type Device struct {
-	Id                     types.String `tfsdk:"id"`
-	Domain                 types.String `tfsdk:"domain"`
-	Name                   types.String `tfsdk:"name"`
-	Type                   types.String `tfsdk:"type"`
-	Host                   types.String `tfsdk:"host"`
-	NatId                  types.String `tfsdk:"nat_id"`
-	Licenses               types.Set    `tfsdk:"licenses"`
-	RegistrationKey        types.String `tfsdk:"registration_key"`
-	DeviceGroupId          types.String `tfsdk:"device_group_id"`
-	ProhibitPacketTransfer types.Bool   `tfsdk:"prohibit_packet_transfer"`
-	PerformanceTier        types.String `tfsdk:"performance_tier"`
-	SnortEngine            types.String `tfsdk:"snort_engine"`
-	ObjectGroupSearch      types.Bool   `tfsdk:"object_group_search"`
-	AccessControlPolicyId  types.String `tfsdk:"access_control_policy_id"`
-	NatPolicyId            types.String `tfsdk:"nat_policy_id"`
-	HealthPolicyId         types.String `tfsdk:"health_policy_id"`
-	ContainerId            types.String `tfsdk:"container_id"`
-	ContainerType          types.String `tfsdk:"container_type"`
-	ContainerName          types.String `tfsdk:"container_name"`
-	ContainerRole          types.String `tfsdk:"container_role"`
-	ContainerStatus        types.String `tfsdk:"container_status"`
-	IsPartOfContainer      types.Bool   `tfsdk:"is_part_of_container"`
-	IsMultiInstance        types.Bool   `tfsdk:"is_multi_instance"`
+	Id                        types.String `tfsdk:"id"`
+	Domain                    types.String `tfsdk:"domain"`
+	Name                      types.String `tfsdk:"name"`
+	Type                      types.String `tfsdk:"type"`
+	Host                      types.String `tfsdk:"host"`
+	NatId                     types.String `tfsdk:"nat_id"`
+	Licenses                  types.Set    `tfsdk:"licenses"`
+	RegistrationKey           types.String `tfsdk:"registration_key"`
+	DeviceGroupId             types.String `tfsdk:"device_group_id"`
+	ProhibitPacketTransfer    types.Bool   `tfsdk:"prohibit_packet_transfer"`
+	PerformanceTier           types.String `tfsdk:"performance_tier"`
+	SnortEngine               types.String `tfsdk:"snort_engine"`
+	ObjectGroupSearch         types.Bool   `tfsdk:"object_group_search"`
+	AccessControlPolicyId     types.String `tfsdk:"access_control_policy_id"`
+	AccessControlPolicyDomain types.String `tfsdk:"access_control_policy_domain"`
+	NatPolicyId               types.String `tfsdk:"nat_policy_id"`
+	NatPolicyDomain           types.String `tfsdk:"nat_policy_domain"`
+	HealthPolicyId            types.String `tfsdk:"health_policy_id"`
+	HealthPolicyDomain        types.String `tfsdk:"health_policy_domain"`
+	ContainerId               types.String `tfsdk:"container_id"`
+	ContainerType             types.String `tfsdk:"container_type"`
+	ContainerName             types.String `tfsdk:"container_name"`
+	ContainerRole             types.String `tfsdk:"container_role"`
+	ContainerStatus           types.String `tfsdk:"container_status"`
+	IsPartOfContainer         types.Bool   `tfsdk:"is_part_of_container"`
+	IsMultiInstance           types.Bool   `tfsdk:"is_multi_instance"`
 }
 
 // End of section. //template:end types
@@ -376,8 +379,10 @@ func (data *Device) fromBodyUnknowns(ctx context.Context, res gjson.Result) {
 
 // End of section. //template:end fromBodyUnknowns
 
-// Fill response with policies IDs obtained from different API endpoint
-func (data *Device) fromBodyPolicy(ctx context.Context, res gjson.Result, policies gjson.Result) gjson.Result {
+// Fill response with policies IDs obtained from different API endpoint.
+// The `policies` map is keyed by FMC policy type and holds the policy assignments listing fetched from the domain
+// in which that particular policy exists.
+func (data *Device) fromBodyPolicy(ctx context.Context, res gjson.Result, policies map[string]gjson.Result) gjson.Result {
 	deviceId := data.Id.ValueString()
 
 	// If device is member of HAPair or Cluster, we should use that ID for policy management
@@ -386,40 +391,40 @@ func (data *Device) fromBodyPolicy(ctx context.Context, res gjson.Result, polici
 	}
 
 	query := fmt.Sprintf(`items.#(targets.#(id=="%s"))#.policy`, deviceId)
-	list := policies.Get(query)
-	tflog.Debug(ctx, fmt.Sprintf("gjson path %s resulted in %d policies for update: %s", query, len(list.Array()), list))
 
-	if !list.Exists() {
-		tflog.Error(ctx, fmt.Sprintf("No mandatory policies found for device %s", data.Id.ValueString()))
-		return res
+	// Response field to be filled in per policy type.
+	// Altough AccessPolicy ID exists in device object, it may have different upper/lower cases in ID, which causes problems when compared with tfstate
+	resFields := map[string]string{
+		"AccessPolicy": "accessPolicy.id",
+		"FTDNatPolicy": "dummy_nat_policy_id",
+		"HealthPolicy": "healthPolicy.id",
 	}
 
 	var ret = res.String()
 
-	// Altough AccessPolicy ID exists in device object, it may have different upper/lower cases in ID, which causes problems when compared with tfstate
-	value := list.Get(`#(type=="AccessPolicy").id`)
-	tflog.Debug(ctx, fmt.Sprintf("gjson search AccessPolicy resulted in: %s", value))
-	if value.Exists() {
-		ret, _ = sjson.Set(ret, "accessPolicy.id", value.String())
-	}
+	for _, policyType := range []string{"AccessPolicy", "FTDNatPolicy", "HealthPolicy"} {
+		assignments, ok := policies[policyType]
+		if !ok {
+			continue
+		}
 
-	value = list.Get(`#(type=="FTDNatPolicy").id`)
-	tflog.Debug(ctx, fmt.Sprintf("gjson search FTDNatPolicy resulted in: %s", value))
-	if value.Exists() {
-		ret, _ = sjson.Set(ret, "dummy_nat_policy_id", value.String())
-	}
+		list := assignments.Get(query)
+		tflog.Debug(ctx, fmt.Sprintf("gjson path %s resulted in %d policies for update: %s", query, len(list.Array()), list))
 
-	value = list.Get(`#(type=="HealthPolicy").id`)
-	tflog.Debug(ctx, fmt.Sprintf("gjson search HealthPolicy resulted in: %s", value))
-	if value.Exists() {
-		ret, _ = sjson.Set(ret, "healthPolicy.id", value.String())
+		value := list.Get(fmt.Sprintf(`#(type=="%s").id`, policyType))
+		tflog.Debug(ctx, fmt.Sprintf("gjson search %s resulted in: %s", policyType, value))
+		if value.Exists() {
+			ret, _ = sjson.Set(ret, resFields[policyType], value.String())
+		} else {
+			tflog.Debug(ctx, fmt.Sprintf("No %s assignment found for device %s", policyType, data.Id.ValueString()))
+		}
 	}
 
 	return gjson.Parse(ret)
 }
 
 // Rewrite Computed values from state to plan
-func (data *Device) copyComputed(ctx context.Context, state Device) {
+func (data *Device) copyComputed(_ context.Context, state Device) {
 	data.ContainerId = state.ContainerId
 	data.ContainerType = state.ContainerType
 	data.ContainerName = state.ContainerName

--- a/internal/provider/resource_fmc_device.go
+++ b/internal/provider/resource_fmc_device.go
@@ -156,12 +156,24 @@ func (r *DeviceResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the assigned Access Control Policy.").String,
 				Required:            true,
 			},
+			"access_control_policy_domain": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Name of the FMC domain in which the assigned Access Control Policy exists. If not set, the device's `domain` is assumed.").String,
+				Optional:            true,
+			},
 			"nat_policy_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the assigned FTD NAT policy.").String,
 				Optional:            true,
 			},
+			"nat_policy_domain": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Name of the FMC domain in which the assigned FTD NAT Policy exists. If not set, the device's `domain` is assumed.").String,
+				Optional:            true,
+			},
 			"health_policy_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Id of the assigned Health policy. Every device requires health policy assignment, hence removal of this attribute does not trigger health policy de-assignment.").String,
+				Optional:            true,
+			},
+			"health_policy_domain": schema.StringAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Name of the FMC domain in which the assigned Health Policy exists. If not set, the device's `domain` is assumed.").String,
 				Optional:            true,
 			},
 			"container_id": schema.StringAttribute{
@@ -270,7 +282,8 @@ func (r *DeviceResource) Create(ctx context.Context, req resource.CreateRequest,
 	tflog.Debug(ctx, fmt.Sprintf("%s: Configuring the non-access policy assignments", plan.Id.ValueString()))
 
 	if !plan.NatPolicyId.IsNull() {
-		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("nat_policy_id"), req.Plan, resp.State, reqMods...)
+		natReqMods := policyReqMods(resolvePolicyDomain(plan.NatPolicyDomain, plan.Domain))
+		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("nat_policy_id"), req.Plan, resp.State, natReqMods...)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -293,7 +306,8 @@ func (r *DeviceResource) Create(ctx context.Context, req resource.CreateRequest,
 	// On device registration, default health policy is auto assigned. We are waiting till that is finished. (see loop above)
 	// Health policy assignment triggers automatic deployment.
 	if !plan.HealthPolicyId.IsNull() {
-		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, resp.State, reqMods...)
+		healthReqMods := policyReqMods(resolvePolicyDomain(plan.HealthPolicyDomain, plan.Domain))
+		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, resp.State, healthReqMods...)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -337,11 +351,26 @@ func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	// Get policy assignments for the device
-	policies, err := r.client.Get("/api/fmc_config/v1/domain/{DOMAIN_UUID}/assignment/policyassignments?expanded=true", reqMods...)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve Policy Assignments (GET), got error: %s, %s", err, policies.String()))
-		return
+	// Get policy assignments for the device. Each policy may reside in a different domain, hence policy assignments
+	// are fetched from every domain in use (only once per domain).
+	policyDomains := map[string]string{
+		"AccessPolicy": resolvePolicyDomain(state.AccessControlPolicyDomain, state.Domain),
+		"FTDNatPolicy": resolvePolicyDomain(state.NatPolicyDomain, state.Domain),
+		"HealthPolicy": resolvePolicyDomain(state.HealthPolicyDomain, state.Domain),
+	}
+
+	assignmentsByDomain := make(map[string]gjson.Result, len(policyDomains))
+	policies := make(map[string]gjson.Result, len(policyDomains))
+	for policyType, domain := range policyDomains {
+		if _, ok := assignmentsByDomain[domain]; !ok {
+			assignments, err := r.client.Get("/api/fmc_config/v1/domain/{DOMAIN_UUID}/assignment/policyassignments?expanded=true", policyReqMods(domain)...)
+			if err != nil {
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve Policy Assignments (GET), got error: %s, %s", err, assignments.String()))
+				return
+			}
+			assignmentsByDomain[domain] = assignments
+		}
+		policies[policyType] = assignmentsByDomain[domain]
 	}
 
 	imp, diags := helpers.IsFlagImporting(ctx, req)
@@ -393,6 +422,16 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Update", plan.Id.ValueString()))
 
+	// Health policy is always assigned per device
+	if plan.HealthPolicyId != state.HealthPolicyId {
+		healthReqMods := policyReqMods(resolvePolicyDomain(plan.HealthPolicyDomain, plan.Domain))
+		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, req.State, healthReqMods...)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if state.ContainerType.ValueString() == "DeviceHAPair" && state.ContainerStatus.ValueString() != "Active" {
 		tflog.Info(ctx, fmt.Sprintf("%s: Device %s is in HA Pair, with current status: %s, hence cannot be updated. Configuration will be replicated from active node.", state.Id.ValueString(), state.Name.ValueString(), state.ContainerStatus.ValueString()))
 		plan.copyComputed(ctx, state)
@@ -431,7 +470,8 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Update policy assignments
 	if plan.AccessControlPolicyId != state.AccessControlPolicyId {
-		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("access_control_policy_id"), req.Plan, req.State, reqMods...)
+		acpReqMods := policyReqMods(resolvePolicyDomain(plan.AccessControlPolicyDomain, plan.Domain))
+		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("access_control_policy_id"), req.Plan, req.State, acpReqMods...)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -439,15 +479,8 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	if plan.NatPolicyId != state.NatPolicyId {
-		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("nat_policy_id"), req.Plan, req.State, reqMods...)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
-	if plan.HealthPolicyId != state.HealthPolicyId {
-		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("health_policy_id"), req.Plan, req.State, reqMods...)
+		natReqMods := policyReqMods(resolvePolicyDomain(plan.NatPolicyDomain, plan.Domain))
+		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("nat_policy_id"), req.Plan, req.State, natReqMods...)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -468,6 +501,25 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
+}
+
+// resolvePolicyDomain returns the name of the domain in which a policy exists. Policies may reside in a different
+// domain than the device itself, hence a per-policy domain can be configured. If it is not set, device's domain is assumed.
+func resolvePolicyDomain(policyDomain, deviceDomain types.String) string {
+	if !policyDomain.IsNull() && policyDomain.ValueString() != "" {
+		return policyDomain.ValueString()
+	}
+	return deviceDomain.ValueString()
+}
+
+// policyReqMods translates a domain name into request modifiers. Empty domain name means that no modifier is applied,
+// hence the provider-level default domain is used.
+func policyReqMods(domain string) []func(*fmc.Req) {
+	reqMods := [](func(*fmc.Req)){}
+	if domain != "" {
+		reqMods = append(reqMods, fmc.DomainName(domain))
+	}
+	return reqMods
 }
 
 // updatePolicy updates policy-to-device assignment of one specific device (UUID) and of one specific policy type

--- a/internal/provider/resource_fmc_device.go
+++ b/internal/provider/resource_fmc_device.go
@@ -282,8 +282,7 @@ func (r *DeviceResource) Create(ctx context.Context, req resource.CreateRequest,
 	tflog.Debug(ctx, fmt.Sprintf("%s: Configuring the non-access policy assignments", plan.Id.ValueString()))
 
 	if !plan.NatPolicyId.IsNull() {
-		natReqMods := policyReqMods(resolvePolicyDomain(plan.NatPolicyDomain, plan.Domain))
-		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("nat_policy_id"), req.Plan, resp.State, natReqMods...)
+		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("nat_policy_id"), req.Plan, resp.State)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -306,8 +305,7 @@ func (r *DeviceResource) Create(ctx context.Context, req resource.CreateRequest,
 	// On device registration, default health policy is auto assigned. We are waiting till that is finished. (see loop above)
 	// Health policy assignment triggers automatic deployment.
 	if !plan.HealthPolicyId.IsNull() {
-		healthReqMods := policyReqMods(resolvePolicyDomain(plan.HealthPolicyDomain, plan.Domain))
-		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, resp.State, healthReqMods...)
+		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, resp.State)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -351,12 +349,22 @@ func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	imp, diags := helpers.IsFlagImporting(ctx, req)
+	if resp.Diagnostics.Append(diags...); resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Get policy assignments for the device. Each policy may reside in a different domain, hence policy assignments
-	// are fetched from every domain in use (only once per domain).
+	// are fetched from every domain in use (only once per domain). Policies that are not assigned are not looked up,
+	// with the exception of `terraform import`, where the state is not populated yet and all policies must be discovered.
 	policyDomains := map[string]string{
 		"AccessPolicy": resolvePolicyDomain(state.AccessControlPolicyDomain, state.Domain),
-		"FTDNatPolicy": resolvePolicyDomain(state.NatPolicyDomain, state.Domain),
-		"HealthPolicy": resolvePolicyDomain(state.HealthPolicyDomain, state.Domain),
+	}
+	if imp || !state.NatPolicyId.IsNull() {
+		policyDomains["FTDNatPolicy"] = resolvePolicyDomain(state.NatPolicyDomain, state.Domain)
+	}
+	if imp || !state.HealthPolicyId.IsNull() {
+		policyDomains["HealthPolicy"] = resolvePolicyDomain(state.HealthPolicyDomain, state.Domain)
 	}
 
 	assignmentsByDomain := make(map[string]gjson.Result, len(policyDomains))
@@ -365,17 +373,12 @@ func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		if _, ok := assignmentsByDomain[domain]; !ok {
 			assignments, err := r.client.Get("/api/fmc_config/v1/domain/{DOMAIN_UUID}/assignment/policyassignments?expanded=true", policyReqMods(domain)...)
 			if err != nil {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve Policy Assignments (GET), got error: %s, %s", err, assignments.String()))
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve Policy Assignments (GET) from domain %s, got error: %s, %s", displayDomain(domain), err, assignments.String()))
 				return
 			}
 			assignmentsByDomain[domain] = assignments
 		}
 		policies[policyType] = assignmentsByDomain[domain]
-	}
-
-	imp, diags := helpers.IsFlagImporting(ctx, req)
-	if resp.Diagnostics.Append(diags...); resp.Diagnostics.HasError() {
-		return
 	}
 
 	// Update body with policy assignments
@@ -424,8 +427,7 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Health policy is always assigned per device
 	if plan.HealthPolicyId != state.HealthPolicyId {
-		healthReqMods := policyReqMods(resolvePolicyDomain(plan.HealthPolicyDomain, plan.Domain))
-		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, req.State, healthReqMods...)
+		diags = r.updatePolicy(ctx, plan.Id.ValueString(), "Device", path.Root("health_policy_id"), req.Plan, req.State)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -470,8 +472,7 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Update policy assignments
 	if plan.AccessControlPolicyId != state.AccessControlPolicyId {
-		acpReqMods := policyReqMods(resolvePolicyDomain(plan.AccessControlPolicyDomain, plan.Domain))
-		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("access_control_policy_id"), req.Plan, req.State, acpReqMods...)
+		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("access_control_policy_id"), req.Plan, req.State)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -479,8 +480,7 @@ func (r *DeviceResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	if plan.NatPolicyId != state.NatPolicyId {
-		natReqMods := policyReqMods(resolvePolicyDomain(plan.NatPolicyDomain, plan.Domain))
-		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("nat_policy_id"), req.Plan, req.State, natReqMods...)
+		diags = r.updatePolicy(ctx, deviceId, deviceType, path.Root("nat_policy_id"), req.Plan, req.State)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -522,9 +522,23 @@ func policyReqMods(domain string) []func(*fmc.Req) {
 	return reqMods
 }
 
+// displayDomain renders a domain name for diagnostics. Empty domain name means the provider-level default domain.
+func displayDomain(domain string) string {
+	if domain == "" {
+		return "Global"
+	}
+	return domain
+}
+
+// policyDomainPath maps an attribute holding a policy id to the attribute holding the domain of that policy,
+// eg. `nat_policy_id` to `nat_policy_domain`.
+func policyDomainPath(policyPath path.Path) path.Path {
+	return path.Root(strings.TrimSuffix(policyPath.String(), "_id") + "_domain")
+}
+
 // updatePolicy updates policy-to-device assignment of one specific device (UUID) and of one specific policy type
 // (policyPath points to a different attribute for Access Policy, NAT Policy, Platform Settings Policy, etc.).
-func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, deviceType string, policyPath path.Path, plan tfsdk.Plan, state tfsdk.State, reqMods ...func(*fmc.Req)) diag.Diagnostics {
+func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, deviceType string, policyPath path.Path, plan tfsdk.Plan, state tfsdk.State) diag.Diagnostics {
 	var planPolicy, statePolicy types.String
 
 	if diags := plan.GetAttribute(ctx, policyPath, &planPolicy); diags.HasError() {
@@ -540,6 +554,25 @@ func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, devi
 	if statePolicy.Equal(planPolicy) {
 		return nil
 	}
+
+	// A policy may exist in a different domain than the device itself. When the policy is being de-assigned, the
+	// assignment lives in the domain recorded in the state, otherwise the planned domain applies.
+	var policyDomain, deviceDomain types.String
+	var diags diag.Diagnostics
+	if planPolicy.IsNull() {
+		diags.Append(state.GetAttribute(ctx, policyDomainPath(policyPath), &policyDomain)...)
+		diags.Append(state.GetAttribute(ctx, path.Root("domain"), &deviceDomain)...)
+	} else {
+		diags.Append(plan.GetAttribute(ctx, policyDomainPath(policyPath), &policyDomain)...)
+		diags.Append(plan.GetAttribute(ctx, path.Root("domain"), &deviceDomain)...)
+	}
+	if diags.HasError() {
+		return diags
+	}
+
+	domain := resolvePolicyDomain(policyDomain, deviceDomain)
+	reqMods := policyReqMods(domain)
+	domainHint := fmt.Sprintf("Verify that `%s` is the domain in which the policy exists (set via `%s`, defaulting to the device's `domain`).", displayDomain(domain), policyDomainPath(policyPath))
 
 	// Marginal risk of data race follows (GET/PUT).
 	// Partial self-protection in case user specifies terraform -parallelism 2 or more:
@@ -557,7 +590,7 @@ func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, devi
 		} else if err != nil {
 			return diag.Diagnostics{diag.NewErrorDiagnostic(
 				"Client Error",
-				fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s", err, res.String()),
+				fmt.Sprintf("Failed to retrieve object (GET), got error: %s, %s\n%s", err, res.String(), domainHint),
 			)}
 		}
 		targets := res.Get(fmt.Sprintf(`targets.#(id != "%s")#`, deviceId))
@@ -575,7 +608,7 @@ func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, devi
 		if err != nil {
 			return diag.Diagnostics{diag.NewErrorDiagnostic(
 				"Client Error",
-				fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()),
+				fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s\n%s", err, res.String(), domainHint),
 			)}
 		}
 		return nil
@@ -594,7 +627,7 @@ func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, devi
 		if err != nil {
 			return diag.Diagnostics{diag.NewErrorDiagnostic(
 				"Client Error",
-				fmt.Sprintf("Failed to configure object (POST), got error: %s, %s", err, res.String()),
+				fmt.Sprintf("Failed to configure object (POST), got error: %s, %s\n%s", err, res.String(), domainHint),
 			)}
 		}
 		return nil
@@ -634,7 +667,7 @@ func (r *DeviceResource) updatePolicy(ctx context.Context, deviceId string, devi
 	if err != nil {
 		return diag.Diagnostics{diag.NewErrorDiagnostic(
 			"Client Error",
-			fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()),
+			fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s\n%s", err, res.String(), domainHint),
 		)}
 	}
 

--- a/internal/provider/resource_fmc_device_test.go
+++ b/internal/provider/resource_fmc_device_test.go
@@ -82,6 +82,10 @@ resource "fmc_access_control_policy" "test" {
   name = "fmc_device_access_control_policy"
   default_action = "BLOCK"
 }
+
+resource "fmc_ftd_nat_policy" "test" {
+  name        = "fmc_device_nat_policy"
+}
 `
 
 // End of section. //template:end testPrerequisites
@@ -112,6 +116,7 @@ func testAccFmcDeviceConfig_all() string {
 	config += `	performance_tier = "FTDv5"` + "\n"
 	config += `	snort_engine = "SNORT3"` + "\n"
 	config += `	access_control_policy_id = fmc_access_control_policy.test.id` + "\n"
+	config += `	nat_policy_id = fmc_ftd_nat_policy.test.id` + "\n"
 	config += `}` + "\n"
 	return config
 }

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,6 +10,7 @@ description: |-
 ## Unreleased
 
 - (Enhancement) Performance improvements
+- (Enhancement) `fmc_device`: Add `access_control_policy_domain`, `nat_policy_domain` and `health_policy_domain` to support policies that exist in a different domain than the device
 - (Enhancement) `fmc_device_physical_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_etherchannel_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_subinterface`: Increase the maximum MTU from `9000` to `9198`

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -14,6 +14,7 @@ description: |-
 - (Enhancement) `fmc_device_physical_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_etherchannel_interface`: Increase the maximum MTU from `9000` to `9198`
 - (Enhancement) `fmc_device_subinterface`: Increase the maximum MTU from `9000` to `9198`
+- (Fix) `fmc_device`: Fix wrong assignment of `health_policy_id` in HA Pair and Cluster configurations
 
 ## 2.5.0
 


### PR DESCRIPTION
- (Enhancement) `fmc_device`: Add `access_control_policy_domain`, `nat_policy_domain` and `health_policy_domain` to support policies that exist in a different domain than the device